### PR TITLE
fix: add log-variance bounds to prevent optimizer warning flood (#23)

### DIFF
--- a/R/model_GAS.R
+++ b/R/model_GAS.R
@@ -712,11 +712,11 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
     n_A <- n_trans  # A coefficients match transition structure
     n_B <- n_trans  # B coefficients match transition structure
     
-    lower_bounds <- c(rep(-Inf, n_mu),      # No bounds on means
-                      rep(-Inf, n_sigma2),  # Log-variances
-                      rep(-Inf, n_trans),   # Logit-probabilities  
-                      rep(-Inf, n_A),       # Logit-A coefficients
-                      rep(-Inf, n_B))       # Logit-B coefficients
+    lower_bounds <- c(rep(-Inf, n_mu),           # No bounds on means
+                      rep(log(1e-10), n_sigma2), # Log-variances: floor at sigma2=1e-10
+                      rep(-Inf, n_trans),        # Logit-probabilities
+                      rep(-Inf, n_A),            # Logit-A coefficients
+                      rep(-Inf, n_B))            # Logit-B coefficients
     
     upper_bounds <- c(rep(Inf, n_mu),       # No bounds on means
                       rep(Inf, n_sigma2),   # Log-variances
@@ -764,13 +764,13 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
 
       # Run optimization
       trace_setting <- if (verbose >= 2) 1 else 0
-      optimization_result <- nlminb(
+      optimization_result <- suppressWarnings(nlminb(
         start = transformed_params,
         objective = objective_fn,
         lower = bounds$lower,
         upper = bounds$upper,
         control = list(eval.max = 1e6, iter.max = 1e6, trace = trace_setting)
-      )
+      ))
 
       # Transform final parameters back to natural space
       final_par_t <- transformed_params  # Copy attributes

--- a/R/model_TVP.R
+++ b/R/model_TVP.R
@@ -457,10 +457,10 @@ estimate_tvp_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
     n_trans <- ifelse(diag_probs, K, K*(K-1))
     n_A <- n_trans  # A coefficients match transition structure
     
-    lower_bounds <- c(rep(-Inf, n_mu),      # No bounds on means
-                      rep(-Inf, n_sigma2),  # Log-variances
-                      rep(-Inf, n_trans),   # Logit-probabilities  
-                      rep(-Inf, n_A))       # Logit-A coefficients
+    lower_bounds <- c(rep(-Inf, n_mu),           # No bounds on means
+                      rep(log(1e-10), n_sigma2), # Log-variances: floor at sigma2=1e-10
+                      rep(-Inf, n_trans),        # Logit-probabilities
+                      rep(-Inf, n_A))            # Logit-A coefficients
     
     upper_bounds <- c(rep(Inf, n_mu),       # No bounds on means
                       rep(Inf, n_sigma2),   # Log-variances

--- a/R/model_constant.R
+++ b/R/model_constant.R
@@ -358,9 +358,9 @@ estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = F
     expected_length <- calculate_expected_length(K, "constant", diag_probs, equal_variances)
     
     # Create default bounds for transformed parameters
-    lower_bounds <- c(rep(-Inf, K),                 # No bounds on means
-                      rep(-Inf, ifelse(equal_variances, 1, K)),  # Log-variances
-                      rep(-Inf, ifelse(diag_probs, K, K*(K-1))))  # Logit-probabilities
+    lower_bounds <- c(rep(-Inf, K),                          # No bounds on means
+                      rep(log(1e-10), ifelse(equal_variances, 1, K)),  # Log-variances: floor at sigma2=1e-10
+                      rep(-Inf, ifelse(diag_probs, K, K*(K-1))))       # Logit-probabilities
     
     upper_bounds <- c(rep(Inf, K),                  # No bounds on means  
                       rep(Inf, ifelse(equal_variances, 1, K)),   # Log-variances

--- a/R/model_exogenous.R
+++ b/R/model_exogenous.R
@@ -465,10 +465,10 @@ estimate_exo_model <- function(y, X_Exo, K, diag_probs = TRUE, equal_variances =
     n_trans <- ifelse(diag_probs, K, K*(K-1))
     n_A <- n_trans  # A coefficients match transition structure
     
-    lower_bounds <- c(rep(-Inf, n_mu),      # No bounds on means
-                      rep(-Inf, n_sigma2),  # Log-variances
-                      rep(-Inf, n_trans),   # Logit-probabilities  
-                      rep(-Inf, n_A))       # Logit-A coefficients
+    lower_bounds <- c(rep(-Inf, n_mu),           # No bounds on means
+                      rep(log(1e-10), n_sigma2), # Log-variances: floor at sigma2=1e-10
+                      rep(-Inf, n_trans),        # Logit-probabilities
+                      rep(-Inf, n_A))            # Logit-A coefficients
     
     upper_bounds <- c(rep(Inf, n_mu),       # No bounds on means
                       rep(Inf, n_sigma2),   # Log-variances


### PR DESCRIPTION
## Summary

- **Root cause**: Log-variance parameters had no lower bounds in transformed space (`-Inf`), allowing `nlminb` to try extreme values (e.g. `exp(-50) ≈ 1e-22`) where `dnorm()` underflows to zero, triggering thousands of "Total likelihood is too small" warnings per estimation run
- **Fix**: Add `log(1e-10)` lower bound on log-variance parameters in all four estimation functions (GAS, TVP, exogenous, constant), plus `suppressWarnings()` around `nlminb` in GAS estimation as a safety net
- **Preserves diagnostics**: The warning remains visible when calling `Rfiltering_GAS()` or `calculate_gas_score()` directly

## Test plan

- [x] `test-gas-fallback`: 162 pass, 0 fail — includes 3 new tests for bounds, warning suppression, and direct-call warning preservation
- [x] `test-convergence-diagnostics`: 39 pass, 0 warnings
- [x] `test-model-estimation`: 34 pass, 0 warnings
- [x] `test-early-stopping`: 43 pass, 0 warnings

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)