### PR TITLE
feat: update early_stop_patience default from 500 to 3000

### DIFF
--- a/R/model_GAS.R
+++ b/R/model_GAS.R
@@ -604,7 +604,8 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
 #' @param use_fallback Whether to automatically use constant model fallback when A is small (default: TRUE)
 #' @param A_threshold Threshold below which to use constant model fallback (default: 1e-4)
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
-#' @param early_stop_patience Evaluations without improvement before stopping (default: 500)
+#' @param early_stop_patience Evaluations without improvement before stopping
+#'   (default: 3000, calibrated from K=3 estimation on real data)
 #' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
@@ -633,7 +634,7 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
                                n_nodes = 30, scaling_method = NULL,
                                use_fallback = TRUE, A_threshold = 1e-4,
                                early_stopping = FALSE,
-                               early_stop_patience = 500L,
+                               early_stop_patience = 3000L,
                                early_stop_max_evals = 50000L,
                                parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
   

--- a/R/model_TVP.R
+++ b/R/model_TVP.R
@@ -359,7 +359,8 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
 #' @param C Cut-off observations to exclude (default: 50)
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
-#' @param early_stop_patience Evaluations without improvement before stopping (default: 500)
+#' @param early_stop_patience Evaluations without improvement before stopping
+#'   (default: 3000, calibrated from K=3 estimation on real data)
 #' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
@@ -386,7 +387,7 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
 estimate_tvp_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
                                n_starts = 10, B = 100, C = 50, bounds = NULL,
                                early_stopping = FALSE,
-                               early_stop_patience = 500L,
+                               early_stop_patience = 3000L,
                                early_stop_max_evals = 50000L,
                                parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
   

--- a/R/model_constant.R
+++ b/R/model_constant.R
@@ -265,7 +265,8 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
 #' @param C Cut-off observations to exclude (default: 50)
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
-#' @param early_stop_patience Evaluations without improvement before stopping (default: 500)
+#' @param early_stop_patience Evaluations without improvement before stopping
+#'   (default: 3000, calibrated from K=3 estimation on real data)
 #' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
@@ -292,7 +293,7 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
 estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
                                     n_starts = 10, B = 100, C = 50, bounds = NULL,
                                     early_stopping = FALSE,
-                                    early_stop_patience = 500L,
+                                    early_stop_patience = 3000L,
                                     early_stop_max_evals = 50000L,
                                     parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
   

--- a/R/model_exogenous.R
+++ b/R/model_exogenous.R
@@ -359,7 +359,8 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
 #' @param C Cut-off observations to exclude (default: 50)
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
-#' @param early_stop_patience Evaluations without improvement before stopping (default: 500)
+#' @param early_stop_patience Evaluations without improvement before stopping
+#'   (default: 3000, calibrated from K=3 estimation on real data)
 #' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
@@ -387,7 +388,7 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
 estimate_exo_model <- function(y, X_Exo, K, diag_probs = TRUE, equal_variances = FALSE,
                                n_starts = 10, B = 100, C = 50, bounds = NULL,
                                early_stopping = FALSE,
-                               early_stop_patience = 500L,
+                               early_stop_patience = 3000L,
                                early_stop_max_evals = 50000L,
                                parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
   

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -603,7 +603,7 @@ generate_starting_points <- function(y, K, model_type = c("constant", "tvp", "ex
 #'
 #' @param enabled Logical; whether early stopping is active.
 #' @param patience Integer; number of evaluations without improvement before
-#'   stopping. Default 500.
+#'   stopping. Default 3000 (calibrated from K=3 estimation on real data).
 #' @param rel_tol Numeric; minimum relative improvement to count as progress.
 #'   Default 1e-8.
 #' @param max_objective Numeric; objective values above this trigger immediate
@@ -612,7 +612,7 @@ generate_starting_points <- function(y, K, model_type = c("constant", "tvp", "ex
 #' @return A list with the configuration values.
 #' @keywords internal
 create_early_stop_config <- function(enabled = FALSE,
-                                     patience = 500L,
+                                     patience = 3000L,
                                      rel_tol = 1e-8,
                                      max_objective = 1e10,
                                      max_evals = 50000L) {

--- a/man/create_early_stop_config.Rd
+++ b/man/create_early_stop_config.Rd
@@ -6,7 +6,7 @@
 \usage{
 create_early_stop_config(
   enabled = FALSE,
-  patience = 500L,
+  patience = 3000L,
   rel_tol = 1e-08,
   max_objective = 1e+10,
   max_evals = 50000L
@@ -16,7 +16,7 @@ create_early_stop_config(
 \item{enabled}{Logical; whether early stopping is active.}
 
 \item{patience}{Integer; number of evaluations without improvement before
-stopping. Default 500.}
+stopping. Default 3000 (calibrated from K=3 estimation on real data).}
 
 \item{rel_tol}{Numeric; minimum relative improvement to count as progress.
 Default 1e-8.}

--- a/man/estimate_constant_model.Rd
+++ b/man/estimate_constant_model.Rd
@@ -14,7 +14,7 @@ estimate_constant_model(
   C = 50,
   bounds = NULL,
   early_stopping = FALSE,
-  early_stop_patience = 500L,
+  early_stop_patience = 3000L,
   early_stop_max_evals = 50000L,
   parallel = TRUE,
   cores = NULL,
@@ -41,7 +41,8 @@ estimate_constant_model(
 
 \item{early_stopping}{Enable early stopping for diverging starts (default: FALSE)}
 
-\item{early_stop_patience}{Evaluations without improvement before stopping (default: 500)}
+\item{early_stop_patience}{Evaluations without improvement before stopping
+(default: 3000, calibrated from K=3 estimation on real data)}
 
 \item{early_stop_max_evals}{Maximum evaluations per start (default: 50000)}
 

--- a/man/estimate_exo_model.Rd
+++ b/man/estimate_exo_model.Rd
@@ -15,7 +15,7 @@ estimate_exo_model(
   C = 50,
   bounds = NULL,
   early_stopping = FALSE,
-  early_stop_patience = 500L,
+  early_stop_patience = 3000L,
   early_stop_max_evals = 50000L,
   parallel = TRUE,
   cores = NULL,
@@ -44,7 +44,8 @@ estimate_exo_model(
 
 \item{early_stopping}{Enable early stopping for diverging starts (default: FALSE)}
 
-\item{early_stop_patience}{Evaluations without improvement before stopping (default: 500)}
+\item{early_stop_patience}{Evaluations without improvement before stopping
+(default: 3000, calibrated from K=3 estimation on real data)}
 
 \item{early_stop_max_evals}{Maximum evaluations per start (default: 50000)}
 

--- a/man/estimate_gas_model.Rd
+++ b/man/estimate_gas_model.Rd
@@ -18,7 +18,7 @@ estimate_gas_model(
   use_fallback = TRUE,
   A_threshold = 1e-04,
   early_stopping = FALSE,
-  early_stop_patience = 500L,
+  early_stop_patience = 3000L,
   early_stop_max_evals = 50000L,
   parallel = TRUE,
   cores = NULL,
@@ -53,7 +53,8 @@ estimate_gas_model(
 
 \item{early_stopping}{Enable early stopping for diverging starts (default: FALSE)}
 
-\item{early_stop_patience}{Evaluations without improvement before stopping (default: 500)}
+\item{early_stop_patience}{Evaluations without improvement before stopping
+(default: 3000, calibrated from K=3 estimation on real data)}
 
 \item{early_stop_max_evals}{Maximum evaluations per start (default: 50000)}
 

--- a/man/estimate_tvp_model.Rd
+++ b/man/estimate_tvp_model.Rd
@@ -14,7 +14,7 @@ estimate_tvp_model(
   C = 50,
   bounds = NULL,
   early_stopping = FALSE,
-  early_stop_patience = 500L,
+  early_stop_patience = 3000L,
   early_stop_max_evals = 50000L,
   parallel = TRUE,
   cores = NULL,
@@ -41,7 +41,8 @@ estimate_tvp_model(
 
 \item{early_stopping}{Enable early stopping for diverging starts (default: FALSE)}
 
-\item{early_stop_patience}{Evaluations without improvement before stopping (default: 500)}
+\item{early_stop_patience}{Evaluations without improvement before stopping
+(default: 3000, calibrated from K=3 estimation on real data)}
 
 \item{early_stop_max_evals}{Maximum evaluations per start (default: 50000)}
 

--- a/tests/testthat/test-early-stopping.R
+++ b/tests/testthat/test-early-stopping.R
@@ -110,7 +110,7 @@ test_that("non-finite objective values return penalty without triggering early s
 test_that("create_early_stop_config returns correct defaults", {
   config <- create_early_stop_config()
   expect_false(config$enabled)
-  expect_equal(config$patience, 500L)
+  expect_equal(config$patience, 3000L)
   expect_equal(config$rel_tol, 1e-8)
   expect_equal(config$max_objective, 1e10)
   expect_equal(config$max_evals, 50000L)


### PR DESCRIPTION
## Summary

- Update `early_stop_patience` default from `500L` to `3000L` across all 4 model estimators and `create_early_stop_config()`, based on calibration study results
- Update roxygen docs to note the calibration basis
- Update unit test assertion to match new default

## Calibration basis

K=3, 20 starts x 3 maturities on real Liu-Wu yield curve data showed `patience=500` was too aggressive:

| Model | Converged | Median evals | Max evals |
|-------|-----------|-------------|-----------|
| Constant | 58/60 | 1,365 | 11,834 |
| TVP | 39/60 | 5,995 | 59,722 |
| Exogenous | 5/60 | 1,907 | 22,351 |

`patience=3000` (2x constant median) covers the constant model comfortably and is reasonable for TVP/exogenous. `max_evals=50000` unchanged.

## Test plan

- [x] Early stopping tests pass (43/43)
- [x] `devtools::check()` passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)