### PR TITLE
fix: clamp off-diagonal row sums to prevent invalid transition matrices (#31)

### DIFF
--- a/R/model_GAS.R
+++ b/R/model_GAS.R
@@ -124,7 +124,8 @@ dataGASCD <- function(M, N, par, burn_in = 100, n_nodes = 30,
     # Use clamped logistic to match original HMMGAS C implementation
     # This maps f directly to [1e-10, 1-1e-10] for numerical stability
     p_trans[,1] <- f_to_params_loop(f[,1])
-    
+    if (!diag_probs) p_trans[,1] <- clamp_offdiag_rowsums(p_trans[,1], K)
+
     # Initialize score as zero
     score_scaled[,1] <- 0
     
@@ -182,6 +183,7 @@ dataGASCD <- function(M, N, par, burn_in = 100, n_nodes = 30,
       
       # Convert f to transition parameters
       p_trans[,t+1] <- f_to_params_loop(f[,t+1])
+      if (!diag_probs) p_trans[,t+1] <- clamp_offdiag_rowsums(p_trans[,t+1], K)
     }
 
     # For the last time point - use generalized formula
@@ -407,6 +409,7 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
 
   # Compute transition probabilities at t=1
   p_trans[, 1] <- f_to_params(f[, 1])
+  if (!diag_probs) p_trans[, 1] <- clamp_offdiag_rowsums(p_trans[, 1], K)
 
   # Compute stationary distribution using eigenvalue method (works for any K>=2)
   stationary_probs <- stat_dist(p_trans[, 1], diag_probs = diag_probs)
@@ -470,6 +473,7 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
     f[, 2] <- omega + A * score_scaled[, 2] + B * (f[, 1] - omega)
     # Use clamped logistic for p_trans[,2] to match C code (lines 125-126)
     p_trans[, 2] <- f_to_params_loop(f[, 2])
+    if (!diag_probs) p_trans[, 2] <- clamp_offdiag_rowsums(p_trans[, 2], K)
   }
 
   # =============================================================================
@@ -535,6 +539,7 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
 
       # Convert f to transition probabilities using clamped logistic
       p_trans[, t+1] <- f_to_params_loop(f[, t+1])
+      if (!diag_probs) p_trans[, t+1] <- clamp_offdiag_rowsums(p_trans[, t+1], K)
     }
   }
 

--- a/R/model_TVP.R
+++ b/R/model_TVP.R
@@ -92,6 +92,7 @@ dataTVPCD <- function(M, N, par, burn_in = 100) {
     # Set f[1] = omega_LR (long-run value)
     f[, 1] <- omega_LR
     p_trans[, 1] <- f_to_params(f[, 1])
+    if (!diag_probs) p_trans[, 1] <- clamp_offdiag_rowsums(p_trans[, 1], K)
 
     # Compute initial predicted probabilities using stationary distribution
     # This works for any K>=2 using eigenvalue-based stationary distribution
@@ -117,6 +118,7 @@ dataTVPCD <- function(M, N, par, burn_in = 100) {
       # This is done at the BEGINNING of each iteration (matching original)
       f[, t + 1] <- omega + A * y.sim[t]
       p_trans[, t + 1] <- f_to_params(f[, t + 1])
+      if (!diag_probs) p_trans[, t + 1] <- clamp_offdiag_rowsums(p_trans[, t + 1], K)
 
       # Compute predicted probabilities X_tlag[t+1] using generalized formula
       # Works for any K>=2
@@ -237,6 +239,7 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
   # At t=1, use omega_LR (long-run value) for initial transition probabilities
   f[, 1] <- omega_LR
   p_trans[, 1] <- f_to_params(f[, 1])
+  if (!diag_probs) p_trans[, 1] <- clamp_offdiag_rowsums(p_trans[, 1], K)
 
   # Compute initial predicted probabilities using stationary distribution
   # This works for any K>=2 using eigenvalue-based stationary distribution
@@ -261,6 +264,7 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
   if (M >= 2) {
     f[, 2] <- omega
     p_trans[, 2] <- f_to_params(f[, 2])
+    if (!diag_probs) p_trans[, 2] <- clamp_offdiag_rowsums(p_trans[, 2], K)
   }
 
   # =========================================================================
@@ -287,6 +291,7 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
       if (t < M - 1) {
         f[, t+1] <- omega + A * y[t]
         p_trans[, t+1] <- f_to_params(f[, t+1])
+        if (!diag_probs) p_trans[, t+1] <- clamp_offdiag_rowsums(p_trans[, t+1], K)
       }
     }
   }
@@ -299,6 +304,7 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
     if (M > 2) {
       f[, M] <- omega + A * y[M-1]
       p_trans[, M] <- f_to_params(f[, M])
+      if (!diag_probs) p_trans[, M] <- clamp_offdiag_rowsums(p_trans[, M], K)
     }
 
     # Generate predicted probabilities using generalized formula

--- a/R/model_exogenous.R
+++ b/R/model_exogenous.R
@@ -89,6 +89,7 @@ dataTVPXExoCD <- function(M, N, par, X_Exo, burn_in = 100) {
     # =========================================================================
     f[, 1] <- omega + A * X_Exo[1]
     p_trans[, 1] <- f_to_params(f[, 1])
+    if (!diag_probs) p_trans[, 1] <- clamp_offdiag_rowsums(p_trans[, 1], K)
 
     # Compute initial predicted probabilities using stationary distribution
     # This works for any K>=2 using eigenvalue-based stationary distribution
@@ -108,6 +109,7 @@ dataTVPXExoCD <- function(M, N, par, X_Exo, burn_in = 100) {
     # Set f[,2] using exogenous variable at index 2
     f[, 2] <- omega + A * X_Exo[2]
     p_trans[, 2] <- f_to_params(f[, 2])
+    if (!diag_probs) p_trans[, 2] <- clamp_offdiag_rowsums(p_trans[, 2], K)
 
     # =========================================================================
     # MAIN LOOP (t=1 to total_length-2): Generalized for K>=2
@@ -135,6 +137,7 @@ dataTVPXExoCD <- function(M, N, par, X_Exo, burn_in = 100) {
       # Update f for next time step using exogenous variable
       f[, t + 2] <- omega + A * X_Exo[t + 2]
       p_trans[, t + 2] <- f_to_params(f[, t + 2])
+      if (!diag_probs) p_trans[, t + 2] <- clamp_offdiag_rowsums(p_trans[, t + 2], K)
     }
 
     # Remove burn-in and save the simulation run
@@ -241,6 +244,7 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
   # =========================================================================
   f[, 1] <- omega + A * X_Exo[1]
   p_trans[, 1] <- f_to_params(f[, 1])
+  if (!diag_probs) p_trans[, 1] <- clamp_offdiag_rowsums(p_trans[, 1], K)
 
   # Compute initial predicted probabilities using stationary distribution
   # This works for any K>=2 using eigenvalue-based stationary distribution
@@ -261,6 +265,7 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
   if (M >= 2) {
     f[, 2] <- omega + A * X_Exo[2]
     p_trans[, 2] <- f_to_params(f[, 2])
+    if (!diag_probs) p_trans[, 2] <- clamp_offdiag_rowsums(p_trans[, 2], K)
   }
 
   # =========================================================================
@@ -286,6 +291,7 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
       if (t < M - 1) {
         f[, t+1] <- omega + A * X_Exo[t+1]
         p_trans[, t+1] <- f_to_params(f[, t+1])
+        if (!diag_probs) p_trans[, t+1] <- clamp_offdiag_rowsums(p_trans[, t+1], K)
       }
     }
   }
@@ -298,6 +304,7 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
     if (M > 2) {
       f[, M] <- omega + A * X_Exo[M]
       p_trans[, M] <- f_to_params(f[, M])
+      if (!diag_probs) p_trans[, M] <- clamp_offdiag_rowsums(p_trans[, M], K)
     }
 
     # Generate predicted probabilities using generalized formula


### PR DESCRIPTION
## Summary

- **Root cause**: With `diag_probs=FALSE`, independent logistic transforms on each off-diagonal transition probability don't prevent their row-sum from exceeding 1, making the diagonal negative → invalid transition matrix → crash in `stat_dist()` → `validate_transition_matrix()`
- **Fix**: Add `clamp_offdiag_rowsums()` helper that proportionally scales down off-diagonal entries per row when their sum exceeds `1 - 1e-6`. Applied after every `f_to_params()` call in all 3 time-varying models (TVP, exogenous, GAS)
- **Result**: Exogenous model goes from 2/20 → 20/20 successful starting points on real Liu-Wu yield data (K=3, `diag_probs=FALSE`)

## Test plan

- [x] All 474 existing tests pass (0 failures, 146 pre-existing GAS fallback warnings)
- [x] 4 new regression tests added for `clamp_offdiag_rowsums()` and the specific exogenous/TVP failure cases
- [x] Verified on real calibration data: 20/20 exogenous starting points now complete (was 2/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)