### PR TITLE
feat: rename B/B_burnin → n_burnin and C → n_cutoff

### DIFF
--- a/R/model_GAS.R
+++ b/R/model_GAS.R
@@ -230,8 +230,8 @@ dataGASCD <- function(M, N, par, burn_in = 100, n_nodes = 30,
 #'
 #' @param par Parameter vector with attributes (mu, sigma2, init_trans, A, B)
 #' @param y Observed time series increments
-#' @param B_burnin Burn-in to be excluded at the beginning of the time series
-#' @param C Cut-off to be excluded at the end of the time series
+#' @param n_burnin Burn-in to be excluded at the beginning of the time series
+#' @param n_cutoff Cut-off to be excluded at the end of the time series
 #' @param n_nodes Number of Gauss-Hermite quadrature nodes (default: 30)
 #' @param scaling_method Score scaling method ("moore_penrose", "simple", "normalized", or "factored")
 #' @param use_fallback Whether to automatically use constant model fallback when A is small (default: TRUE)
@@ -259,7 +259,7 @@ dataGASCD <- function(M, N, par, burn_in = 100, n_nodes = 30,
 #' y <- rnorm(200)
 #' loglik <- Rfiltering_GAS(par_diag, y, 20, 10)
 #' @export
-Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = NULL,
+Rfiltering_GAS <- function(par, y, n_burnin, n_cutoff, n_nodes = 30, scaling_method = NULL,
                            use_fallback = TRUE, A_threshold = 1e-4, diagnostics = FALSE, verbose = FALSE) {
   
   # Only validate if diagnostics are enabled (performance optimization)
@@ -306,7 +306,7 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
       )
       
       # Use fast constant model filtering
-      result <- Rfiltering_Const(const_par, y, B_burnin, C, diagnostics = diagnostics)
+      result <- Rfiltering_Const(const_par, y, n_burnin, n_cutoff, diagnostics = diagnostics)
       
       # Add GAS-specific attributes if diagnostics enabled
       if (diagnostics) {
@@ -544,7 +544,7 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
   }
   
   # Sum log-likelihoods, but exclude burn-in and cut-off
-  valid_indices <- (B_burnin+1):(M-C)
+  valid_indices <- (n_burnin+1):(M-n_cutoff)
   if (length(valid_indices) <= 0) {
     stop("Error: No valid data points after applying burn-in and cut-off.")
   }
@@ -596,8 +596,8 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
 #' @param diag_probs If TRUE, use diagonal transition probability parameterization
 #' @param equal_variances If TRUE, constrain all regimes to have equal variances
 #' @param n_starts Number of random starting points for optimization (default: 10)
-#' @param B_burnin Burn-in observations to exclude (default: 100)
-#' @param C Cut-off observations to exclude (default: 50)
+#' @param n_burnin Burn-in observations to exclude (default: 100)
+#' @param n_cutoff Cut-off observations to exclude (default: 50)
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param n_nodes Number of Gauss-Hermite quadrature nodes (default: 30)
 #' @param scaling_method Score scaling method (default: "simple")
@@ -622,15 +622,15 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
 #' # Estimate model with diagonal probabilities
 #' y <- rnorm(200)
 #' result_diag <- estimate_gas_model(y, K=2, diag_probs=TRUE, n_starts=3,
-#'                                   B_burnin=20, C=10)
+#'                                   n_burnin=20, n_cutoff=10)
 #'
 #' # Estimate model with off-diagonal probabilities
 #' result_offdiag <- estimate_gas_model(y, K=2, diag_probs=FALSE, n_starts=3,
-#'                                      B_burnin=20, C=10)
+#'                                      n_burnin=20, n_cutoff=10)
 #' }
 #' @export
 estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
-                               n_starts = 10, B_burnin = 100, C = 50, bounds = NULL,
+                               n_starts = 10, n_burnin = 100, n_cutoff = 50, bounds = NULL,
                                n_nodes = 30, scaling_method = NULL,
                                use_fallback = TRUE, A_threshold = 1e-4,
                                early_stopping = FALSE,
@@ -645,7 +645,7 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
   if (!is.numeric(K) || K < 2 || K != as.integer(K)) {
     stop("K must be an integer >= 2")
   }
-  if (length(y) <= B_burnin + C + K) {
+  if (length(y) <= n_burnin + n_cutoff + K) {
     stop("Time series too short for specified burn-in and cut-off")
   }
   
@@ -670,7 +670,7 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
     cat("Estimating GAS (score-driven) regime-switching model\n")
     cat("==================================================\n")
     cat("K:", K, "regimes\n")
-    cat("Data points:", length(y), "(using", length(y) - B_burnin - C, "after burn-in/cut-off)\n")
+    cat("Data points:", length(y), "(using", length(y) - n_burnin - n_cutoff, "after burn-in/cut-off)\n")
     cat("Parameterization:", ifelse(diag_probs, "diagonal", "off-diagonal"), "transition probabilities\n")
     cat("Variances:", ifelse(equal_variances, "equal (shared)", "separate"), "\n")
     cat("Starting points:", n_starts, "\n")
@@ -746,7 +746,7 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
         par_t_with_attrs[] <- par_t
         attr(par_t_with_attrs, "parameterization") <- "transformed"
         par_natural <- untransform_parameters(par_t_with_attrs)
-        neg_log_lik <- Rfiltering_GAS(par_natural, y, B_burnin, C,
+        neg_log_lik <- Rfiltering_GAS(par_natural, y, n_burnin, n_cutoff,
                                       n_nodes = n_nodes, scaling_method = scaling_method,
                                       use_fallback = use_fallback, A_threshold = A_threshold,
                                       diagnostics = FALSE, verbose = FALSE)
@@ -874,13 +874,13 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
 
   # Calculate model diagnostics
   num_params <- length(estimated_params)
-  num_data_points <- length(y) - B_burnin - C
+  num_data_points <- length(y) - n_burnin - n_cutoff
 
   aic <- 2 * optimization_result$objective + 2 * num_params
   bic <- 2 * optimization_result$objective + num_params * log(num_data_points)
   
   # Calculate filtered probabilities and additional diagnostics (with full diagnostics)
-  full_likelihood_result <- Rfiltering_GAS(estimated_params, y, B_burnin, C,
+  full_likelihood_result <- Rfiltering_GAS(estimated_params, y, n_burnin, n_cutoff,
                                            n_nodes = n_nodes, scaling_method = scaling_method,
                                            use_fallback = use_fallback, A_threshold = A_threshold,
                                            diagnostics = TRUE, verbose = (verbose >= 2))
@@ -928,8 +928,8 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
     ),
     data_info = list(
       n_obs = length(y),
-      burn_in = B_burnin,
-      cut_off = C,
+      burn_in = n_burnin,
+      cut_off = n_cutoff,
       n_used = num_data_points
     ),
     filtered_probabilities = attr(full_likelihood_result, "X.t"),

--- a/R/model_constant.R
+++ b/R/model_constant.R
@@ -118,8 +118,8 @@ dataConstCD <- function(M, N, par, burn_in = 100) {
 #'
 #' @param par Parameter vector with attributes (mu, sigma2, trans_prob)
 #' @param y Observed time series increments
-#' @param B Burn-in to be excluded at the beginning of the time series
-#' @param C Cut-off to be excluded at the end of the time series
+#' @param n_burnin Burn-in to be excluded at the beginning of the time series
+#' @param n_cutoff Cut-off to be excluded at the end of the time series
 #' @param diagnostics Choose whether to store calculation diagnostics or not
 #' @return Negative log-likelihood of observed data under the model
 #' @details
@@ -135,9 +135,9 @@ dataConstCD <- function(M, N, par, burn_in = 100) {
 #' par_diag <- set_parameter_attributes(par_diag, K=2, model_type="constant",
 #'                                      diag_probs=TRUE, equal_variances=FALSE)
 #' y <- rnorm(200)
-#' loglik <- Rfiltering_Const(par_diag, y, 20, 10)
+#' loglik <- Rfiltering_Const(par_diag, y, n_burnin = 20, n_cutoff = 10)
 #' @export
-Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
+Rfiltering_Const <- function(par, y, n_burnin, n_cutoff, diagnostics = FALSE) {
   
   # Validate parameter vector and extract configuration
   if (diagnostics) {
@@ -221,7 +221,7 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
   }
   
   # Sum log-likelihoods, but exclude burn-in and cut-off
-  valid_indices <- (B+1):(M-C)
+  valid_indices <- (n_burnin+1):(M-n_cutoff)
   if (length(valid_indices) <= 0) {
     stop("Error: No valid data points after applying burn-in and cut-off.")
   }
@@ -261,8 +261,8 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
 #' @param diag_probs If TRUE, use diagonal transition probability parameterization
 #' @param equal_variances If TRUE, constrain all regimes to have equal variances
 #' @param n_starts Number of random starting points for optimization (default: 10)
-#' @param B Burn-in observations to exclude (default: 100)
-#' @param C Cut-off observations to exclude (default: 50)
+#' @param n_burnin Burn-in observations to exclude (default: 100)
+#' @param n_cutoff Cut-off observations to exclude (default: 50)
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
 #' @param early_stop_patience Evaluations without improvement before stopping
@@ -283,15 +283,15 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
 #' # Estimate model with diagonal probabilities (original style)
 #' y <- rnorm(200)
 #' result_diag <- estimate_constant_model(y, K=2, diag_probs=TRUE, n_starts=3,
-#'                                        B=20, C=10)
+#'                                        n_burnin=20, n_cutoff=10)
 #'
 #' # Estimate model with off-diagonal probabilities (new style)
 #' result_offdiag <- estimate_constant_model(y, K=2, diag_probs=FALSE, n_starts=3,
-#'                                           B=20, C=10)
+#'                                           n_burnin=20, n_cutoff=10)
 #' }
 #' @export
 estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
-                                    n_starts = 10, B = 100, C = 50, bounds = NULL,
+                                    n_starts = 10, n_burnin = 100, n_cutoff = 50, bounds = NULL,
                                     early_stopping = FALSE,
                                     early_stop_patience = 3000L,
                                     early_stop_max_evals = 50000L,
@@ -304,7 +304,7 @@ estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = F
   if (!is.numeric(K) || K < 2 || K != as.integer(K)) {
     stop("K must be an integer >= 2")
   }
-  if (length(y) <= B + C + K) {
+  if (length(y) <= n_burnin + n_cutoff + K) {
     stop("Time series too short for specified burn-in and cut-off")
   }
   
@@ -329,7 +329,7 @@ estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = F
     cat("Estimating constant transition probability model\n")
     cat("==============================================\n")
     cat("K:", K, "regimes\n")
-    cat("Data points:", length(y), "(using", length(y) - B - C, "after burn-in/cut-off)\n")
+    cat("Data points:", length(y), "(using", length(y) - n_burnin - n_cutoff, "after burn-in/cut-off)\n")
     cat("Parameterization:", ifelse(diag_probs, "diagonal", "off-diagonal"), "transition probabilities\n")
     cat("Variances:", ifelse(equal_variances, "equal (shared)", "separate"), "\n")
     cat("Starting points:", n_starts, "\n")
@@ -388,7 +388,7 @@ estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = F
         par_t_with_attrs[] <- par_t
         attr(par_t_with_attrs, "parameterization") <- "transformed"
         par_natural <- untransform_parameters(par_t_with_attrs)
-        neg_log_lik <- Rfiltering_Const(par_natural, y, B, C)
+        neg_log_lik <- Rfiltering_Const(par_natural, y, n_burnin, n_cutoff)
         return(neg_log_lik)
       }
 
@@ -513,13 +513,13 @@ estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = F
   
   # Calculate model diagnostics
   num_params <- length(estimated_params)
-  num_data_points <- length(y) - B - C
+  num_data_points <- length(y) - n_burnin - n_cutoff
   
   aic <- 2 * optimization_result$objective + 2 * num_params
   bic <- 2 * optimization_result$objective + num_params * log(num_data_points)
   
   # Calculate filtered probabilities and additional diagnostics
-  full_likelihood_result <- Rfiltering_Const(estimated_params, y, B, C)
+  full_likelihood_result <- Rfiltering_Const(estimated_params, y, n_burnin, n_cutoff)
   
   # Clean up parallel processing
   if (parallel) {
@@ -553,8 +553,8 @@ estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = F
     ),
     data_info = list(
       n_obs = length(y),
-      burn_in = B,
-      cut_off = C,
+      burn_in = n_burnin,
+      cut_off = n_cutoff,
       n_used = num_data_points
     ),
     filtered_probabilities = attr(full_likelihood_result, "X.t"),

--- a/tests/testthat/helper-parameter-recovery.R
+++ b/tests/testthat/helper-parameter-recovery.R
@@ -15,8 +15,8 @@ RECOVERY_NEAR_ZERO_THRESHOLD <- 0.05
 RECOVERY_NEAR_ZERO_ABS_TOL   <- 0.15
 
 RECOVERY_SIM_BURNIN <- 200L
-RECOVERY_FILTER_B   <- 100L
-RECOVERY_FILTER_C   <- 10L
+RECOVERY_FILTER_BURNIN <- 100L
+RECOVERY_FILTER_CUTOFF <- 10L
 RECOVERY_N_STARTS   <- 10L
 
 # --- Permutation helpers ------------------------------------------------------
@@ -254,25 +254,25 @@ recovery_run_single <- function(scenario, seed = 42L) {
     diag_probs      = scenario$diag_probs,
     equal_variances = scenario$equal_variances,
     n_starts        = RECOVERY_N_STARTS,
-    C               = RECOVERY_FILTER_C,
+    n_cutoff        = RECOVERY_FILTER_CUTOFF,
     parallel        = TRUE,
     seed            = seed + 1000L,
     verbose         = 0L
   )
 
   if (scenario$model_type == "gas") {
-    est_args$B_burnin     <- RECOVERY_FILTER_B
+    est_args$n_burnin     <- RECOVERY_FILTER_BURNIN
     est_args$use_fallback <- FALSE
     est_result <- do.call(estimate_gas_model, est_args)
   } else if (scenario$model_type == "exo") {
-    est_args$B     <- RECOVERY_FILTER_B
-    est_args$X_Exo <- X_Exo_full[1:N]
+    est_args$n_burnin <- RECOVERY_FILTER_BURNIN
+    est_args$X_Exo    <- X_Exo_full[1:N]
     est_result <- do.call(estimate_exo_model, est_args)
   } else if (scenario$model_type == "tvp") {
-    est_args$B <- RECOVERY_FILTER_B
+    est_args$n_burnin <- RECOVERY_FILTER_BURNIN
     est_result <- do.call(estimate_tvp_model, est_args)
   } else {
-    est_args$B <- RECOVERY_FILTER_B
+    est_args$n_burnin <- RECOVERY_FILTER_BURNIN
     est_result <- do.call(estimate_constant_model, est_args)
   }
 

--- a/tests/testthat/test-convergence-diagnostics.R
+++ b/tests/testthat/test-convergence-diagnostics.R
@@ -26,7 +26,7 @@ test_that("constant filter K=3 off-diagonal unequal-var returns finite NLL", {
   par <- set_parameter_attributes(par, K = 3, model_type = "constant",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_Const(par, y, B = 20, C = 10)
+  nll <- Rfiltering_Const(par, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll), info = paste("NLL was:", nll))
   expect_true(nll > 0)
 })
@@ -40,7 +40,7 @@ test_that("TVP filter K=3 off-diagonal unequal-var A=0 returns finite NLL", {
   par <- set_parameter_attributes(par, K = 3, model_type = "tvp",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_TVP(par, y, B = 20, C = 10)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll), info = paste("NLL was:", nll))
   expect_true(nll > 0)
 })
@@ -55,7 +55,7 @@ test_that("exogenous filter K=3 off-diagonal unequal-var A=0 returns finite NLL"
   par <- set_parameter_attributes(par, K = 3, model_type = "exogenous",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_TVPXExo(par, X_Exo, y, B = 20, C = 10)
+  nll <- Rfiltering_TVPXExo(par, X_Exo, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll), info = paste("NLL was:", nll))
   expect_true(nll > 0)
 })
@@ -69,7 +69,7 @@ test_that("GAS filter K=3 off-diagonal unequal-var A=0 returns finite NLL", {
   par <- set_parameter_attributes(par, K = 3, model_type = "gas",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_GAS(par, y, B_burnin = 20, C = 10,
+  nll <- Rfiltering_GAS(par, y, n_burnin = 20, n_cutoff = 10,
                          use_fallback = FALSE, diagnostics = FALSE)
   expect_true(is.finite(nll), info = paste("NLL was:", nll))
   expect_true(nll > 0)
@@ -92,7 +92,7 @@ test_that("TVP filter K=3 off-diagonal with small A=0.05 returns finite NLL", {
   par <- set_parameter_attributes(par, K = 3, model_type = "tvp",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_TVP(par, y, B = 20, C = 10)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll), info = paste("Small A: NLL was:", nll))
   expect_true(nll > 0)
 })
@@ -108,7 +108,7 @@ test_that("TVP filter K=3 off-diagonal with moderate A=0.5 produces degraded NLL
                                   diag_probs = FALSE, equal_variances = FALSE)
 
   # This may or may not be finite depending on data -- document the behavior
-  nll <- Rfiltering_TVP(par, y, B = 20, C = 10)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 20, n_cutoff = 10)
   # Just check we don't crash; the NLL value documents degradation
   expect_true(is.numeric(nll), info = paste("Moderate A: NLL was:", nll))
 })
@@ -123,7 +123,7 @@ test_that("TVP filter K=3 off-diagonal with large A=2.0 returns finite NLL (logi
   par <- set_parameter_attributes(par, K = 3, model_type = "tvp",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_TVP(par, y, B = 20, C = 10)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll),
               info = paste("Large A off-diagonal: NLL was:", nll))
   expect_true(nll > 0)
@@ -140,7 +140,7 @@ test_that("exogenous filter K=3 off-diagonal with large A=2.0 returns finite NLL
 
   # With logistic link, f-values are squashed to (0,1) before constructing
   # transition matrices, so even large A values produce valid probabilities.
-  nll <- Rfiltering_TVPXExo(par, X_Exo, y, B = 20, C = 10)
+  nll <- Rfiltering_TVPXExo(par, X_Exo, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll),
               info = paste("Exo large A off-diagonal: NLL was:", nll))
   expect_true(nll > 0)
@@ -156,7 +156,7 @@ test_that("TVP filter K=3 DIAGONAL with A=2.0 remains finite (logistic protects)
   par <- set_parameter_attributes(par, K = 3, model_type = "tvp",
                                   diag_probs = TRUE, equal_variances = FALSE)
 
-  nll <- Rfiltering_TVP(par, y, B = 20, C = 10)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 20, n_cutoff = 10)
   # Diagonal case with logistic link should produce finite NLL even with large A
   expect_true(is.finite(nll),
               info = paste("Large A diagonal (logistic): NLL was:", nll))
@@ -173,7 +173,7 @@ test_that("GAS filter K=3 off-diagonal with large A=2.0 returns finite NLL (logi
   par <- set_parameter_attributes(par, K = 3, model_type = "gas",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_GAS(par, y, B_burnin = 20, C = 10,
+  nll <- Rfiltering_GAS(par, y, n_burnin = 20, n_cutoff = 10,
                         use_fallback = FALSE, diagnostics = FALSE)
   expect_true(is.finite(nll),
               info = paste("GAS large A off-diagonal: NLL was:", nll))
@@ -254,7 +254,7 @@ test_that("TVP K=3 off-diagonal starting points all produce finite NLL", {
   n_finite <- 0
   for (i in seq_along(sp_list)) {
     nll <- tryCatch(
-      Rfiltering_TVP(sp_list[[i]], y, B = 20, C = 10),
+      Rfiltering_TVP(sp_list[[i]], y, n_burnin = 20, n_cutoff = 10),
       error = function(e) NA_real_
     )
     if (is.finite(nll)) n_finite <- n_finite + 1
@@ -280,7 +280,7 @@ test_that("exogenous K=3 off-diagonal starting points all produce finite NLL", {
   n_error <- 0
   for (i in seq_along(sp_list)) {
     nll <- tryCatch(
-      Rfiltering_TVPXExo(sp_list[[i]], X_Exo, y, B = 20, C = 10),
+      Rfiltering_TVPXExo(sp_list[[i]], X_Exo, y, n_burnin = 20, n_cutoff = 10),
       error = function(e) { n_error <<- n_error + 1; NA_real_ }
     )
     if (!is.na(nll) && is.finite(nll)) n_finite <- n_finite + 1
@@ -304,7 +304,7 @@ test_that("GAS K=3 off-diagonal starting points all produce finite NLL", {
   n_finite <- 0
   for (i in seq_along(sp_list)) {
     nll <- tryCatch(
-      Rfiltering_GAS(sp_list[[i]], y, B_burnin = 20, C = 10,
+      Rfiltering_GAS(sp_list[[i]], y, n_burnin = 20, n_cutoff = 10,
                      use_fallback = FALSE, diagnostics = FALSE),
       error = function(e) NA_real_
     )
@@ -337,7 +337,7 @@ test_that("TVP/exo starting points: negative omega in logit space is safe with l
   n_finite <- 0
   for (i in seq_along(sp_list)) {
     nll <- tryCatch(
-      Rfiltering_TVP(sp_list[[i]], y, B = 20, C = 10),
+      Rfiltering_TVP(sp_list[[i]], y, n_burnin = 20, n_cutoff = 10),
       error = function(e) NA_real_
     )
     if (is.finite(nll)) n_finite <- n_finite + 1
@@ -366,7 +366,7 @@ test_that("constant K=3 off-diagonal single-start converges (control)", {
   start_params <- sp_list[[1]]
   transformed <- transform_parameters(start_params)
 
-  initial_nll <- Rfiltering_Const(start_params, y, B = 20, C = 10)
+  initial_nll <- Rfiltering_Const(start_params, y, n_burnin = 20, n_cutoff = 10)
 
   opt <- nlminb(
     start = transformed,
@@ -375,7 +375,7 @@ test_that("constant K=3 off-diagonal single-start converges (control)", {
       par_t_with_attrs[] <- par_t
       attr(par_t_with_attrs, "parameterization") <- "transformed"
       par_natural <- untransform_parameters(par_t_with_attrs)
-      Rfiltering_Const(par_natural, y, B = 20, C = 10)
+      Rfiltering_Const(par_natural, y, n_burnin = 20, n_cutoff = 10)
     },
     control = list(eval.max = 500, iter.max = 100, trace = 0)
   )
@@ -397,7 +397,7 @@ test_that("TVP K=3 off-diagonal single-start attempts optimization", {
   start_params <- sp_list[[1]]
   transformed <- transform_parameters(start_params)
 
-  initial_nll <- Rfiltering_TVP(start_params, y, B = 20, C = 10)
+  initial_nll <- Rfiltering_TVP(start_params, y, n_burnin = 20, n_cutoff = 10)
 
   opt <- tryCatch(
     nlminb(
@@ -407,7 +407,7 @@ test_that("TVP K=3 off-diagonal single-start attempts optimization", {
         par_t_with_attrs[] <- par_t
         attr(par_t_with_attrs, "parameterization") <- "transformed"
         par_natural <- untransform_parameters(par_t_with_attrs)
-        Rfiltering_TVP(par_natural, y, B = 20, C = 10)
+        Rfiltering_TVP(par_natural, y, n_burnin = 20, n_cutoff = 10)
       },
       control = list(eval.max = 500, iter.max = 100, trace = 0)
     ),
@@ -434,7 +434,7 @@ test_that("exogenous K=3 off-diagonal single-start attempts optimization", {
   start_params <- sp_list[[1]]
   transformed <- transform_parameters(start_params)
 
-  initial_nll <- Rfiltering_TVPXExo(start_params, X_Exo, y, B = 20, C = 10)
+  initial_nll <- Rfiltering_TVPXExo(start_params, X_Exo, y, n_burnin = 20, n_cutoff = 10)
 
   opt <- tryCatch(
     nlminb(
@@ -444,7 +444,7 @@ test_that("exogenous K=3 off-diagonal single-start attempts optimization", {
         par_t_with_attrs[] <- par_t
         attr(par_t_with_attrs, "parameterization") <- "transformed"
         par_natural <- untransform_parameters(par_t_with_attrs)
-        Rfiltering_TVPXExo(par_natural, X_Exo, y, B = 20, C = 10)
+        Rfiltering_TVPXExo(par_natural, X_Exo, y, n_burnin = 20, n_cutoff = 10)
       },
       control = list(eval.max = 500, iter.max = 100, trace = 0)
     ),
@@ -470,7 +470,7 @@ test_that("GAS K=3 off-diagonal single-start attempts optimization", {
   transformed <- transform_parameters(start_params)
 
   initial_nll <- tryCatch(
-    Rfiltering_GAS(start_params, y, B_burnin = 20, C = 10,
+    Rfiltering_GAS(start_params, y, n_burnin = 20, n_cutoff = 10,
                    use_fallback = FALSE, diagnostics = FALSE),
     error = function(e) Inf
   )
@@ -483,7 +483,7 @@ test_that("GAS K=3 off-diagonal single-start attempts optimization", {
         par_t_with_attrs[] <- par_t
         attr(par_t_with_attrs, "parameterization") <- "transformed"
         par_natural <- untransform_parameters(par_t_with_attrs)
-        Rfiltering_GAS(par_natural, y, B_burnin = 20, C = 10,
+        Rfiltering_GAS(par_natural, y, n_burnin = 20, n_cutoff = 10,
                        use_fallback = FALSE, diagnostics = FALSE)
       },
       control = list(eval.max = 500, iter.max = 100, trace = 0)
@@ -511,7 +511,7 @@ test_that("TVP K=2 off-diagonal estimation converges on synthetic data", {
 
   result <- estimate_tvp_model(
     y, K = 2, diag_probs = FALSE, equal_variances = TRUE,
-    n_starts = 5, B = 20, C = 10, verbose = 0, parallel = FALSE
+    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -528,7 +528,7 @@ test_that("exogenous K=2 off-diagonal estimation converges on synthetic data", {
   # With logistic link, exogenous K=2 off-diagonal should converge
   result <- estimate_exo_model(
     y, X_Exo = X_Exo, K = 2, diag_probs = FALSE, equal_variances = TRUE,
-    n_starts = 5, B = 20, C = 10, verbose = 0, parallel = FALSE
+    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -543,7 +543,7 @@ test_that("GAS K=2 off-diagonal estimation converges on synthetic data", {
 
   result <- estimate_gas_model(
     y, K = 2, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, B_burnin = 20, C = 10, verbose = 0, parallel = FALSE,
+    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE,
     use_fallback = TRUE
   )
 
@@ -567,7 +567,7 @@ test_that("TVP K=3 off-diagonal unequal-var estimation converges", {
 
   result <- estimate_tvp_model(
     y, K = 3, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, B = 20, C = 10, verbose = 0, parallel = FALSE
+    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -582,7 +582,7 @@ test_that("exogenous K=3 off-diagonal unequal-var estimation converges", {
 
   result <- estimate_exo_model(
     y, X_Exo = X_Exo, K = 3, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, B = 20, C = 10, verbose = 0, parallel = FALSE
+    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -596,7 +596,7 @@ test_that("GAS K=3 off-diagonal unequal-var estimation converges", {
 
   result <- estimate_gas_model(
     y, K = 3, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, B_burnin = 20, C = 10, verbose = 0, parallel = FALSE,
+    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE,
     use_fallback = TRUE
   )
 

--- a/tests/testthat/test-early-stopping.R
+++ b/tests/testthat/test-early-stopping.R
@@ -155,7 +155,7 @@ test_that("constant model estimation works with early stopping enabled", {
 
   # Use generous thresholds to avoid prematurely stopping all starts
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 3, B = 20, C = 10, verbose = 0,
+                                    n_starts = 3, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                     parallel = FALSE,
                                     early_stopping = TRUE,
                                     early_stop_patience = 5000,
@@ -174,7 +174,7 @@ test_that("early_stopping=FALSE preserves backward compatibility", {
   y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
 
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 2, B = 20, C = 10, verbose = 0,
+                                    n_starts = 2, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                     parallel = FALSE,
                                     early_stopping = FALSE)
 
@@ -195,7 +195,7 @@ test_that("early-stopped runs never win best-result selection", {
 
   # Use enough starts and generous enough thresholds that at least one converges
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 5, B = 20, C = 10, verbose = 0,
+                                    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                     parallel = FALSE,
                                     early_stopping = TRUE,
                                     early_stop_patience = 5000,
@@ -219,7 +219,7 @@ test_that("TVP model estimation works with early stopping", {
   y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
 
   result <- estimate_tvp_model(y, K = 2, diag_probs = FALSE,
-                               n_starts = 2, B = 20, C = 10, verbose = 0,
+                               n_starts = 2, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                parallel = FALSE,
                                early_stopping = TRUE,
                                early_stop_patience = 5000,

--- a/tests/testthat/test-gas-fallback.R
+++ b/tests/testthat/test-gas-fallback.R
@@ -13,7 +13,7 @@ describe("GAS fallback triggering", {
   # Shared test data for triggering tests
   set.seed(42)
   y_data <- rnorm(300, mean = 0, sd = 1)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("triggers fallback when max(|A|) is below default threshold", {
@@ -21,7 +21,7 @@ describe("GAS fallback triggering", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -35,7 +35,7 @@ describe("GAS fallback triggering", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -50,7 +50,7 @@ describe("GAS fallback triggering", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -63,7 +63,7 @@ describe("GAS fallback triggering", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -76,7 +76,7 @@ describe("GAS fallback triggering", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = FALSE,
                              diagnostics = TRUE)
 
@@ -93,13 +93,13 @@ describe("GAS fallback triggering", {
                                         diag_probs = TRUE, equal_variances = FALSE)
 
     # Default threshold: should NOT trigger fallback
-    result_default <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result_default <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                      use_fallback = TRUE, A_threshold = 1e-4,
                                      diagnostics = TRUE)
     expect_null(attr(result_default, "model_type"))
 
     # Large custom threshold: SHOULD trigger fallback
-    result_custom <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result_custom <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                     use_fallback = TRUE, A_threshold = 0.1,
                                     diagnostics = TRUE)
     expect_equal(attr(result_custom, "model_type"), "constant_fallback")
@@ -111,12 +111,12 @@ describe("GAS fallback triggering", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result_default <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result_default <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                      use_fallback = TRUE, A_threshold = 1e-4,
                                      diagnostics = TRUE)
     expect_equal(attr(result_default, "model_type"), "constant_fallback")
 
-    result_small <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result_small <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                    use_fallback = TRUE, A_threshold = 1e-8,
                                    diagnostics = TRUE)
     gas_diag <- attr(result_small, "gas_diagnostics")
@@ -131,7 +131,7 @@ describe("GAS fallback triggering", {
 describe("GAS fallback likelihood equivalence with direct constant model", {
 
   set.seed(123)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("produces identical likelihood for K=2 diagonal with tiny A", {
@@ -149,9 +149,9 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                      diagnostics = FALSE)
 
     # Exactly identical (same code path via delegation)
@@ -172,9 +172,9 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                      diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -196,9 +196,9 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = TRUE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                      diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -218,9 +218,9 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = FALSE, equal_variances = FALSE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                      diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -240,9 +240,9 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = TRUE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                      diagnostics = TRUE)
 
     expect_equal(attr(gas_result, "X.t"), attr(const_result, "X.t"))
@@ -266,9 +266,9 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
     gas_par <- set_parameter_attributes(gas_par, K = 3, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                      diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -283,7 +283,7 @@ describe("GAS fallback diagnostics", {
 
   set.seed(789)
   y_data <- rnorm(300, mean = 0, sd = 1)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("sets correct diagnostic attributes when fallback is triggered", {
@@ -292,7 +292,7 @@ describe("GAS fallback diagnostics", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -328,7 +328,7 @@ describe("GAS fallback diagnostics", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -346,7 +346,7 @@ describe("GAS fallback diagnostics", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, diagnostics = TRUE)
 
     gas_diag <- attr(result, "gas_diagnostics")
@@ -363,7 +363,7 @@ describe("GAS fallback diagnostics", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, diagnostics = FALSE)
 
     expect_null(attr(result, "model_type"))
@@ -383,7 +383,7 @@ describe("GAS fallback diagnostics", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, diagnostics = TRUE)
 
     # Constant model attributes should be present from the inner Rfiltering_Const call
@@ -401,7 +401,7 @@ describe("GAS fallback diagnostics", {
 describe("GAS fallback edge cases", {
 
   set.seed(456)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("triggers fallback when all A coefficients are exactly zero", {
@@ -411,7 +411,7 @@ describe("GAS fallback edge cases", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, diagnostics = TRUE)
 
     expect_equal(attr(result, "model_type"), "constant_fallback")
@@ -426,7 +426,7 @@ describe("GAS fallback edge cases", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -442,7 +442,7 @@ describe("GAS fallback edge cases", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -457,7 +457,7 @@ describe("GAS fallback edge cases", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -477,7 +477,7 @@ describe("GAS fallback edge cases", {
     gas_par_k3 <- set_parameter_attributes(gas_par_k3, K = 3, model_type = "gas",
                                            diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par_k3, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par_k3, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, diagnostics = TRUE)
 
     expect_equal(attr(result, "model_type"), "constant_fallback")
@@ -512,13 +512,13 @@ describe("GAS fallback edge cases", {
                                               diag_probs = FALSE,
                                               equal_variances = FALSE)
 
-    gas_result <- Rfiltering_GAS(gas_par_k3_od, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par_k3_od, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = TRUE)
 
     expect_equal(attr(gas_result, "model_type"), "constant_fallback")
 
     # Verify likelihood equivalence with direct constant model
-    const_result <- Rfiltering_Const(const_par_k3_od, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par_k3_od, y_data, n_burnin, C_cutoff,
                                      diagnostics = FALSE)
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
   })
@@ -531,7 +531,7 @@ describe("GAS fallback edge cases", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                              use_fallback = TRUE, A_threshold = 1e-4,
                              diagnostics = TRUE)
 
@@ -546,7 +546,7 @@ describe("GAS fallback edge cases", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_short, B_burnin = 5, C = 0,
+    result <- Rfiltering_GAS(gas_par, y_short, n_burnin = 5, n_cutoff = 0,
                              use_fallback = TRUE, diagnostics = FALSE)
 
     expect_true(is.numeric(result))
@@ -572,7 +572,7 @@ describe("GAS fallback integration with estimate_gas_model", {
 
     est_result <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 20, C = 0,
+      n_starts = 1, n_burnin = 20, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -601,7 +601,7 @@ describe("GAS fallback integration with estimate_gas_model", {
 
     est_result <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 20, C = 0,
+      n_starts = 1, n_burnin = 20, n_cutoff = 0,
       use_fallback = FALSE,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -631,7 +631,7 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
   # likelihood differences even when A is effectively zero.
 
   set.seed(2024)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("likelihood is nearly identical for K=2 diagonal with tiny A", {
@@ -649,11 +649,11 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
                                         diag_probs = TRUE, equal_variances = FALSE)
 
     # Full GAS path (fallback disabled)
-    full_gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    full_gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = FALSE, diagnostics = FALSE)
 
     # Constant fallback path
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = TRUE, diagnostics = FALSE)
 
     # Likelihoods should be close (different code paths but A ~ 0)
@@ -677,9 +677,9 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    full_gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    full_gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = FALSE, diagnostics = FALSE)
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = TRUE, diagnostics = FALSE)
 
     expect_equal(as.numeric(full_gas_result), as.numeric(fallback_result),
@@ -700,9 +700,9 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = FALSE, equal_variances = FALSE)
 
-    full_gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    full_gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = FALSE, diagnostics = FALSE)
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = TRUE, diagnostics = FALSE)
 
     expect_equal(as.numeric(full_gas_result), as.numeric(fallback_result),
@@ -728,11 +728,11 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
     # calculation (X_pred probabilities not summing to 1). Use tryCatch
     # to detect this and still validate the fallback works.
     full_gas_result <- tryCatch(
-      Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                      use_fallback = FALSE, diagnostics = FALSE),
       error = function(e) NULL
     )
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = TRUE, diagnostics = FALSE)
 
     # Fallback should always produce a valid result
@@ -762,9 +762,9 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    full_gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    full_gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = FALSE, diagnostics = TRUE)
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                       use_fallback = TRUE, diagnostics = TRUE)
 
     # The two paths use different initialization and indexing conventions.
@@ -784,7 +784,7 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
 
     # After burn-in, regime classifications should mostly agree
     # (which regime has highest probability at each time step)
-    post_burnin <- (B_burnin + 5):ncol(full_Xt)
+    post_burnin <- (n_burnin + 5):ncol(full_Xt)
     full_regime <- apply(full_Xt[, post_burnin], 2, which.max)
     fb_regime <- apply(fb_Xt[, post_burnin], 2, which.max)
     agreement_rate <- mean(full_regime == fb_regime)
@@ -818,9 +818,9 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
       gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                           diag_probs = TRUE, equal_variances = FALSE)
 
-      full_gas <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      full_gas <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = FALSE, diagnostics = FALSE)
-      fallback <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      fallback <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
 
       diffs[i] <- abs(as.numeric(full_gas) - as.numeric(fallback))
@@ -849,7 +849,7 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
 describe("Fallback performance advantage over full GAS", {
   skip_on_cran()
 
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("fallback is faster than full GAS for K=2 N=1000", {
@@ -864,7 +864,7 @@ describe("Fallback performance advantage over full GAS", {
     n_reps <- 5
     time_fallback <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                        use_fallback = TRUE, diagnostics = FALSE)
       }
     })["elapsed"]
@@ -872,7 +872,7 @@ describe("Fallback performance advantage over full GAS", {
     # Time the full GAS path
     time_full_gas <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                        use_fallback = FALSE, diagnostics = FALSE)
       }
     })["elapsed"]
@@ -903,14 +903,14 @@ describe("Fallback performance advantage over full GAS", {
     n_reps <- 3
     time_fallback <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                        use_fallback = TRUE, diagnostics = FALSE)
       }
     })["elapsed"]
 
     time_full_gas <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                        use_fallback = FALSE, diagnostics = FALSE)
       }
     })["elapsed"]
@@ -943,14 +943,14 @@ describe("Fallback performance advantage over full GAS", {
 
       time_fallback <- system.time({
         for (i in seq_len(n_reps)) {
-          Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+          Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                          use_fallback = TRUE, diagnostics = FALSE)
         }
       })["elapsed"]
 
       time_full_gas <- system.time({
         for (i in seq_len(n_reps)) {
-          Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+          Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                          use_fallback = FALSE, diagnostics = FALSE)
         }
       })["elapsed"]
@@ -990,14 +990,14 @@ describe("Fallback performance advantage over full GAS", {
 
     time_fb_diag <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_diag, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par_diag, y_data, n_burnin, C_cutoff,
                        use_fallback = TRUE, diagnostics = FALSE)
       }
     })["elapsed"]
 
     time_gas_diag <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_diag, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par_diag, y_data, n_burnin, C_cutoff,
                        use_fallback = FALSE, diagnostics = FALSE)
       }
     })["elapsed"]
@@ -1009,14 +1009,14 @@ describe("Fallback performance advantage over full GAS", {
 
     time_fb_offdiag <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_offdiag, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par_offdiag, y_data, n_burnin, C_cutoff,
                        use_fallback = TRUE, diagnostics = FALSE)
       }
     })["elapsed"]
 
     time_gas_offdiag <- system.time({
       for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_offdiag, y_data, B_burnin, C_cutoff,
+        Rfiltering_GAS(gas_par_offdiag, y_data, n_burnin, C_cutoff,
                        use_fallback = FALSE, diagnostics = FALSE)
       }
     })["elapsed"]
@@ -1050,7 +1050,7 @@ describe("B-coefficient irrelevance under fallback", {
 
   set.seed(800)
   y_data <- rnorm(300, mean = 0, sd = 1)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("varying B produces identical likelihood for K=2 diagonal", {
@@ -1060,11 +1060,11 @@ describe("B-coefficient irrelevance under fallback", {
                                diag_probs = TRUE, equal_variances = FALSE)
     }
 
-    result_1 <- Rfiltering_GAS(make_gas_par(0.1, 0.1), y_data, B_burnin, C_cutoff,
+    result_1 <- Rfiltering_GAS(make_gas_par(0.1, 0.1), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
-    result_2 <- Rfiltering_GAS(make_gas_par(0.5, 0.5), y_data, B_burnin, C_cutoff,
+    result_2 <- Rfiltering_GAS(make_gas_par(0.5, 0.5), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
-    result_3 <- Rfiltering_GAS(make_gas_par(0.99, 0.99), y_data, B_burnin, C_cutoff,
+    result_3 <- Rfiltering_GAS(make_gas_par(0.99, 0.99), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
 
     # Exact equality (same code path via delegation, B is never used)
@@ -1079,9 +1079,9 @@ describe("B-coefficient irrelevance under fallback", {
                                diag_probs = FALSE, equal_variances = FALSE)
     }
 
-    result_1 <- Rfiltering_GAS(make_gas_par_od(0.1, 0.1), y_data, B_burnin, C_cutoff,
+    result_1 <- Rfiltering_GAS(make_gas_par_od(0.1, 0.1), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
-    result_2 <- Rfiltering_GAS(make_gas_par_od(0.99, 0.99), y_data, B_burnin, C_cutoff,
+    result_2 <- Rfiltering_GAS(make_gas_par_od(0.99, 0.99), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
 
     expect_identical(as.numeric(result_1), as.numeric(result_2))
@@ -1094,9 +1094,9 @@ describe("B-coefficient irrelevance under fallback", {
                                diag_probs = TRUE, equal_variances = FALSE)
     }
 
-    result_1 <- Rfiltering_GAS(make_gas_par(0.1, 0.1), y_data, B_burnin, C_cutoff,
+    result_1 <- Rfiltering_GAS(make_gas_par(0.1, 0.1), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = TRUE)
-    result_2 <- Rfiltering_GAS(make_gas_par(0.99, 0.99), y_data, B_burnin, C_cutoff,
+    result_2 <- Rfiltering_GAS(make_gas_par(0.99, 0.99), y_data, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = TRUE)
 
     expect_identical(attr(result_1, "X.t"), attr(result_2, "X.t"))
@@ -1120,11 +1120,11 @@ describe("B-coefficient irrelevance under fallback", {
                                diag_probs = TRUE, equal_variances = FALSE)
     }
 
-    result_1 <- Rfiltering_GAS(make_gas_k3(0.1, 0.1, 0.1), y_k3, B_burnin, C_cutoff,
+    result_1 <- Rfiltering_GAS(make_gas_k3(0.1, 0.1, 0.1), y_k3, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
-    result_2 <- Rfiltering_GAS(make_gas_k3(0.5, 0.5, 0.5), y_k3, B_burnin, C_cutoff,
+    result_2 <- Rfiltering_GAS(make_gas_k3(0.5, 0.5, 0.5), y_k3, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
-    result_3 <- Rfiltering_GAS(make_gas_k3(0.99, 0.99, 0.99), y_k3, B_burnin, C_cutoff,
+    result_3 <- Rfiltering_GAS(make_gas_k3(0.99, 0.99, 0.99), y_k3, n_burnin, C_cutoff,
                                 use_fallback = TRUE, diagnostics = FALSE)
 
     expect_identical(as.numeric(result_1), as.numeric(result_2))
@@ -1143,7 +1143,7 @@ describe("B-coefficient irrelevance under fallback", {
 describe("Fallback parameter construction correctness", {
 
   set.seed(900)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("K=2 equal_variances=TRUE produces identical NLL to direct constant model", {
@@ -1159,9 +1159,9 @@ describe("Fallback parameter construction correctness", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = TRUE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                   use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                       diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -1180,9 +1180,9 @@ describe("Fallback parameter construction correctness", {
     gas_par <- set_parameter_attributes(gas_par, K = 3, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = TRUE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                   use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                       diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -1202,9 +1202,9 @@ describe("Fallback parameter construction correctness", {
     gas_par <- set_parameter_attributes(gas_par, K = 3, model_type = "gas",
                                         diag_probs = FALSE, equal_variances = TRUE)
 
-    gas_result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                   use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, B_burnin, C_cutoff,
+    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
                                       diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
@@ -1220,7 +1220,7 @@ describe("Fallback parameter construction correctness", {
                                         diag_probs = TRUE, equal_variances = FALSE)
 
     y_data <- rnorm(300)
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = TRUE)
 
     # The fallback should have called Rfiltering_Const which sets model_info
@@ -1257,7 +1257,7 @@ describe("Fallback numerical stability at parameter extremes", {
 
   set.seed(1000)
   y_data <- rnorm(200)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("handles very large mean separation (mu=c(-100, 100))", {
@@ -1265,7 +1265,7 @@ describe("Fallback numerical stability at parameter extremes", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = FALSE)
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
@@ -1278,7 +1278,7 @@ describe("Fallback numerical stability at parameter extremes", {
 
     # Very small variance can produce extreme likelihoods but should not crash
     result <- tryCatch(
-      Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                      use_fallback = TRUE, diagnostics = FALSE),
       error = function(e) NULL
     )
@@ -1293,7 +1293,7 @@ describe("Fallback numerical stability at parameter extremes", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = FALSE)
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
@@ -1304,7 +1304,7 @@ describe("Fallback numerical stability at parameter extremes", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = FALSE)
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
@@ -1315,7 +1315,7 @@ describe("Fallback numerical stability at parameter extremes", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = FALSE)
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
@@ -1326,7 +1326,7 @@ describe("Fallback numerical stability at parameter extremes", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = FALSE)
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
@@ -1337,7 +1337,7 @@ describe("Fallback numerical stability at parameter extremes", {
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, diagnostics = FALSE)
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
@@ -1355,7 +1355,7 @@ describe("Fallback numerical stability at parameter extremes", {
 describe("Likelihood surface continuity at A_threshold boundary", {
 
   set.seed(1100)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("likelihood is nearly identical just below vs just above threshold (K=2 diagonal)", {
@@ -1378,9 +1378,9 @@ describe("Likelihood surface continuity at A_threshold boundary", {
     gas_par_above <- set_parameter_attributes(gas_par_above, K = 2, model_type = "gas",
                                               diag_probs = TRUE, equal_variances = FALSE)
 
-    nll_below <- Rfiltering_GAS(gas_par_below, y_data, B_burnin, C_cutoff,
+    nll_below <- Rfiltering_GAS(gas_par_below, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    nll_above <- Rfiltering_GAS(gas_par_above, y_data, B_burnin, C_cutoff,
+    nll_above <- Rfiltering_GAS(gas_par_above, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
 
     # Relative difference should be small (< 0.1%)
@@ -1407,9 +1407,9 @@ describe("Likelihood surface continuity at A_threshold boundary", {
     gas_par_above <- set_parameter_attributes(gas_par_above, K = 2, model_type = "gas",
                                               diag_probs = FALSE, equal_variances = FALSE)
 
-    nll_below <- Rfiltering_GAS(gas_par_below, y_data, B_burnin, C_cutoff,
+    nll_below <- Rfiltering_GAS(gas_par_below, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
-    nll_above <- Rfiltering_GAS(gas_par_above, y_data, B_burnin, C_cutoff,
+    nll_above <- Rfiltering_GAS(gas_par_above, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
 
     rel_diff <- abs(as.numeric(nll_below) - as.numeric(nll_above)) / abs(as.numeric(nll_below))
@@ -1435,7 +1435,7 @@ describe("Likelihood surface continuity at A_threshold boundary", {
       gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, a, a, 0.85, 0.90)
       gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                           diag_probs = TRUE, equal_variances = FALSE)
-      nlls[i] <- as.numeric(Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      nlls[i] <- as.numeric(Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                             use_fallback = TRUE, diagnostics = FALSE))
     }
 
@@ -1474,12 +1474,12 @@ describe("Likelihood surface continuity at A_threshold boundary", {
     gas_par_above <- set_parameter_attributes(gas_par_above, K = 3, model_type = "gas",
                                               diag_probs = TRUE, equal_variances = FALSE)
 
-    nll_below <- Rfiltering_GAS(gas_par_below, y_data, B_burnin, C_cutoff,
+    nll_below <- Rfiltering_GAS(gas_par_below, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
 
     # K=3 full GAS near threshold can have numerical issues
     nll_above <- tryCatch(
-      Rfiltering_GAS(gas_par_above, y_data, B_burnin, C_cutoff,
+      Rfiltering_GAS(gas_par_above, y_data, n_burnin, C_cutoff,
                      use_fallback = TRUE, diagnostics = FALSE),
       error = function(e) NULL
     )
@@ -1521,7 +1521,7 @@ describe("Round-trip estimation consistency", {
 
     est_result <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -1546,7 +1546,7 @@ describe("Round-trip estimation consistency", {
 
     est_result <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -1572,7 +1572,7 @@ describe("Round-trip estimation consistency", {
 
     est_result <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -1610,14 +1610,14 @@ describe("Estimation accuracy and speed: fallback vs no-fallback", {
 
     est_fallback <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
       parallel = FALSE, verbose = 0, seed = 42
     )
 
     est_no_fallback <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = FALSE,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -1653,7 +1653,7 @@ describe("Estimation accuracy and speed: fallback vs no-fallback", {
     time_fb <- system.time({
       est_fb <- estimate_gas_model(
         y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, B_burnin = 10, C = 0,
+        n_starts = 1, n_burnin = 10, n_cutoff = 0,
         use_fallback = TRUE, A_threshold = 1e-4,
         parallel = FALSE, verbose = 0, seed = 42
       )
@@ -1662,7 +1662,7 @@ describe("Estimation accuracy and speed: fallback vs no-fallback", {
     time_nofb <- system.time({
       est_nofb <- estimate_gas_model(
         y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, B_burnin = 10, C = 0,
+        n_starts = 1, n_burnin = 10, n_cutoff = 0,
         use_fallback = FALSE,
         parallel = FALSE, verbose = 0, seed = 42
       )
@@ -1689,7 +1689,7 @@ describe("Estimation accuracy and speed: fallback vs no-fallback", {
     est_fallback <- tryCatch(
       estimate_gas_model(
         y = y_data, K = 3, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, B_burnin = 10, C = 0,
+        n_starts = 1, n_burnin = 10, n_cutoff = 0,
         use_fallback = TRUE, A_threshold = 1e-4,
         parallel = FALSE, verbose = 0, seed = 42
       ),
@@ -1700,7 +1700,7 @@ describe("Estimation accuracy and speed: fallback vs no-fallback", {
     est_no_fallback <- tryCatch(
       estimate_gas_model(
         y = y_data, K = 3, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, B_burnin = 10, C = 0,
+        n_starts = 1, n_burnin = 10, n_cutoff = 0,
         use_fallback = FALSE,
         parallel = FALSE, verbose = 0, seed = 42
       ),
@@ -1734,14 +1734,14 @@ describe("Estimation accuracy and speed: fallback vs no-fallback", {
 
     est_fb <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
       parallel = FALSE, verbose = 0, seed = 42
     )
 
     est_nofb <- estimate_gas_model(
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, B_burnin = 10, C = 0,
+      n_starts = 1, n_burnin = 10, n_cutoff = 0,
       use_fallback = FALSE,
       parallel = FALSE, verbose = 0, seed = 42
     )
@@ -1772,7 +1772,7 @@ describe("Verbose output coverage", {
 
   set.seed(1400)
   y_data <- rnorm(200)
-  B_burnin <- 20
+  n_burnin <- 20
   C_cutoff <- 0
 
   it("verbose=TRUE produces output when fallback triggers", {
@@ -1782,7 +1782,7 @@ describe("Verbose output coverage", {
 
     # Assign result inside capture.output to prevent R auto-printing the return value
     output <- capture.output(
-      res <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      res <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                             use_fallback = TRUE, verbose = TRUE, diagnostics = FALSE)
     )
 
@@ -1796,7 +1796,7 @@ describe("Verbose output coverage", {
                                         diag_probs = TRUE, equal_variances = FALSE)
 
     output <- capture.output(
-      res <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+      res <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                             use_fallback = TRUE, verbose = TRUE, diagnostics = FALSE)
     )
 
@@ -1812,7 +1812,7 @@ describe("Verbose output coverage", {
     # Assign result to prevent R auto-printing the return value
     output <- capture.output(
       suppressWarnings(
-        res <- Rfiltering_GAS(gas_par, y_data, B_burnin, C_cutoff,
+        res <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                               use_fallback = TRUE, verbose = FALSE, diagnostics = FALSE)
       )
     )
@@ -1853,7 +1853,7 @@ test_that("estimate_gas_model does not flood warnings during optimization", {
   withCallingHandlers(
     result <- estimate_gas_model(y, K = 2, diag_probs = TRUE,
                                   n_starts = 3, verbose = 0,
-                                  B_burnin = 20, C = 10,
+                                  n_burnin = 20, n_cutoff = 10,
                                   parallel = FALSE),
     warning = function(w) {
       warnings_captured <<- c(warnings_captured, conditionMessage(w))
@@ -1880,7 +1880,7 @@ test_that("Rfiltering_GAS still warns when called directly with bad params", {
                                   diag_probs = TRUE, equal_variances = FALSE)
 
   expect_warning(
-    Rfiltering_GAS(par, y, B_burnin = 20, C = 10,
+    Rfiltering_GAS(par, y, n_burnin = 20, n_cutoff = 10,
                    use_fallback = FALSE, diagnostics = FALSE),
     "Total likelihood is too small"
   )

--- a/tests/testthat/test-gas-k3-tolerance.R
+++ b/tests/testthat/test-gas-k3-tolerance.R
@@ -13,7 +13,7 @@ test_that("GAS model K=3 filtering does not crash with tolerance error", {
   y <- c(rnorm(200, -2), rnorm(200, 0), rnorm(200, 2))
 
   expect_no_error(
-    Rfiltering_GAS(par, y, B_burnin = 5, C = 5, use_fallback = FALSE)
+    Rfiltering_GAS(par, y, n_burnin = 5, n_cutoff = 5, use_fallback = FALSE)
   )
 })
 
@@ -27,7 +27,7 @@ test_that("K=3 filtered probabilities are valid after re-normalization", {
 
   y <- c(rnorm(200, -2), rnorm(200, 0), rnorm(200, 2))
 
-  result <- Rfiltering_GAS(par, y, B_burnin = 5, C = 5,
+  result <- Rfiltering_GAS(par, y, n_burnin = 5, n_cutoff = 5,
                             use_fallback = FALSE, diagnostics = TRUE)
   X_t <- attr(result, "X.t")
 

--- a/tests/testthat/test-model-estimation.R
+++ b/tests/testthat/test-model-estimation.R
@@ -96,7 +96,7 @@ test_that("Rfiltering_TVP returns finite likelihood with off-diagonal params", {
   par <- set_parameter_attributes(par, K = 2, model_type = "tvp",
                                   diag_probs = FALSE, equal_variances = TRUE)
 
-  nll <- Rfiltering_TVP(par, y, 100, 50)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 100, n_cutoff = 50)
   expect_true(is.finite(nll))
   expect_true(nll > 0)
 })
@@ -110,7 +110,7 @@ test_that("Rfiltering_TVPXExo returns finite likelihood with off-diagonal params
   par <- set_parameter_attributes(par, K = 2, model_type = "exogenous",
                                   diag_probs = FALSE, equal_variances = TRUE)
 
-  nll <- Rfiltering_TVPXExo(par, X_Exo, y, 100, 50)
+  nll <- Rfiltering_TVPXExo(par, X_Exo, y, n_burnin = 100, n_cutoff = 50)
   expect_true(is.finite(nll))
   expect_true(nll > 0)
 })
@@ -124,7 +124,7 @@ test_that("Rfiltering_GAS returns finite likelihood with off-diagonal params", {
   par <- set_parameter_attributes(par, K = 2, model_type = "gas",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_GAS(par, y, 100, 50)
+  nll <- Rfiltering_GAS(par, y, n_burnin = 100, n_cutoff = 50)
   expect_true(is.finite(nll))
   expect_true(nll > 0)
 })
@@ -137,7 +137,7 @@ test_that("Rfiltering_Const returns finite likelihood with off-diagonal params",
   par <- set_parameter_attributes(par, K = 2, model_type = "constant",
                                   diag_probs = FALSE, equal_variances = TRUE)
 
-  nll <- Rfiltering_Const(par, y, 100, 50)
+  nll <- Rfiltering_Const(par, y, n_burnin = 100, n_cutoff = 50)
   expect_true(is.finite(nll))
   expect_true(nll > 0)
 })
@@ -163,7 +163,7 @@ test_that("Rfiltering_Const works with K=3 off-diagonal", {
   par <- set_parameter_attributes(par, K = 3, model_type = "constant",
                                   diag_probs = FALSE, equal_variances = TRUE)
 
-  nll <- Rfiltering_Const(par, y, 100, 50)
+  nll <- Rfiltering_Const(par, y, n_burnin = 100, n_cutoff = 50)
   expect_true(is.finite(nll))
   expect_true(nll > 0)
 })


### PR DESCRIPTION
## Summary
- Resolves #36: inconsistent burn-in parameter naming across model functions
- Renamed `B`/`B_burnin` → `n_burnin` and `C` → `n_cutoff` across all 4 model types (constant, TVP, exogenous, GAS)
- Updated filtering functions (`Rfiltering_*`), estimation functions (`estimate_*_model`), roxygen docs, examples, and all test files (10 files, 233 lines changed)

## Test plan
- [x] All 4 filtering functions verified with new named parameters
- [x] `test-early-stopping`: 43/43 PASS
- [x] `test-model-estimation`: 34/34 PASS
- [x] `test-gas-k3-tolerance`: 4/4 PASS
- [x] Grep confirms zero remaining `B_burnin`, `est_args$B`, or `est_args$C` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)