### PR TITLE
Update early stopping defaults: patience=10000, max_evals=60000

### DIFF
--- a/R/model_GAS.R
+++ b/R/model_GAS.R
@@ -605,8 +605,8 @@ Rfiltering_GAS <- function(par, y, B_burnin, C, n_nodes = 30, scaling_method = N
 #' @param A_threshold Threshold below which to use constant model fallback (default: 1e-4)
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
 #' @param early_stop_patience Evaluations without improvement before stopping
-#'   (default: 3000, calibrated from K=3 estimation on real data)
-#' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
+#'   (default: 10000, calibrated from K=3 estimation on real data)
+#' @param early_stop_max_evals Maximum evaluations per start (default: 60000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
 #' @param seed Random seed for reproducibility (optional)
@@ -634,8 +634,8 @@ estimate_gas_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
                                n_nodes = 30, scaling_method = NULL,
                                use_fallback = TRUE, A_threshold = 1e-4,
                                early_stopping = FALSE,
-                               early_stop_patience = 3000L,
-                               early_stop_max_evals = 50000L,
+                               early_stop_patience = 10000L,
+                               early_stop_max_evals = 60000L,
                                parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
   
   # Input validation

--- a/R/model_TVP.R
+++ b/R/model_TVP.R
@@ -360,8 +360,8 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
 #' @param early_stop_patience Evaluations without improvement before stopping
-#'   (default: 3000, calibrated from K=3 estimation on real data)
-#' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
+#'   (default: 10000, calibrated from K=3 estimation on real data)
+#' @param early_stop_max_evals Maximum evaluations per start (default: 60000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
 #' @param seed Random seed for reproducibility (optional)
@@ -387,10 +387,10 @@ Rfiltering_TVP <- function(par, y, B, C, diagnostics = FALSE) {
 estimate_tvp_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
                                n_starts = 10, B = 100, C = 50, bounds = NULL,
                                early_stopping = FALSE,
-                               early_stop_patience = 3000L,
-                               early_stop_max_evals = 50000L,
+                               early_stop_patience = 10000L,
+                               early_stop_max_evals = 60000L,
                                parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
-  
+
   # Input validation
   if (!is.numeric(y) || length(y) == 0) {
     stop("y must be a non-empty numeric vector")

--- a/R/model_constant.R
+++ b/R/model_constant.R
@@ -266,8 +266,8 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
 #' @param early_stop_patience Evaluations without improvement before stopping
-#'   (default: 3000, calibrated from K=3 estimation on real data)
-#' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
+#'   (default: 10000, calibrated from K=3 estimation on real data)
+#' @param early_stop_max_evals Maximum evaluations per start (default: 60000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
 #' @param seed Random seed for reproducibility (optional)
@@ -293,8 +293,8 @@ Rfiltering_Const <- function(par, y, B, C, diagnostics = FALSE) {
 estimate_constant_model <- function(y, K, diag_probs = TRUE, equal_variances = FALSE,
                                     n_starts = 10, B = 100, C = 50, bounds = NULL,
                                     early_stopping = FALSE,
-                                    early_stop_patience = 3000L,
-                                    early_stop_max_evals = 50000L,
+                                    early_stop_patience = 10000L,
+                                    early_stop_max_evals = 60000L,
                                     parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
   
   # Input validation

--- a/R/model_exogenous.R
+++ b/R/model_exogenous.R
@@ -360,8 +360,8 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
 #' @param bounds Optional list with lower and upper parameter bounds
 #' @param early_stopping Enable early stopping for diverging starts (default: FALSE)
 #' @param early_stop_patience Evaluations without improvement before stopping
-#'   (default: 3000, calibrated from K=3 estimation on real data)
-#' @param early_stop_max_evals Maximum evaluations per start (default: 50000)
+#'   (default: 10000, calibrated from K=3 estimation on real data)
+#' @param early_stop_max_evals Maximum evaluations per start (default: 60000)
 #' @param parallel Enable parallel processing for multiple starts (default: TRUE)
 #' @param cores Number of cores for parallel processing (default: future::availableCores()-1)
 #' @param seed Random seed for reproducibility (optional)
@@ -388,10 +388,10 @@ Rfiltering_TVPXExo <- function(par, X_Exo, y, B, C, diagnostics = FALSE) {
 estimate_exo_model <- function(y, X_Exo, K, diag_probs = TRUE, equal_variances = FALSE,
                                n_starts = 10, B = 100, C = 50, bounds = NULL,
                                early_stopping = FALSE,
-                               early_stop_patience = 3000L,
-                               early_stop_max_evals = 50000L,
+                               early_stop_patience = 10000L,
+                               early_stop_max_evals = 60000L,
                                parallel = TRUE, cores = NULL, seed = NULL, verbose = 1) {
-  
+
   # Input validation
   if (!is.numeric(y) || length(y) == 0) {
     stop("y must be a non-empty numeric vector")

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -608,14 +608,14 @@ generate_starting_points <- function(y, K, model_type = c("constant", "tvp", "ex
 #'   Default 1e-8.
 #' @param max_objective Numeric; objective values above this trigger immediate
 #'   stopping. Default 1e10.
-#' @param max_evals Integer; maximum total evaluations per start. Default 50000.
+#' @param max_evals Integer; maximum total evaluations per start. Default 60000.
 #' @return A list with the configuration values.
 #' @keywords internal
 create_early_stop_config <- function(enabled = FALSE,
-                                     patience = 3000L,
+                                     patience = 10000L,
                                      rel_tol = 1e-8,
                                      max_objective = 1e10,
-                                     max_evals = 50000L) {
+                                     max_evals = 60000L) {
   list(
     enabled = enabled,
     patience = as.integer(patience),

--- a/tests/testthat/test-early-stopping.R
+++ b/tests/testthat/test-early-stopping.R
@@ -110,10 +110,10 @@ test_that("non-finite objective values return penalty without triggering early s
 test_that("create_early_stop_config returns correct defaults", {
   config <- create_early_stop_config()
   expect_false(config$enabled)
-  expect_equal(config$patience, 3000L)
+  expect_equal(config$patience, 10000L)
   expect_equal(config$rel_tol, 1e-8)
   expect_equal(config$max_objective, 1e10)
-  expect_equal(config$max_evals, 50000L)
+  expect_equal(config$max_evals, 60000L)
 })
 
 test_that("create_early_stop_config respects custom values", {


### PR DESCRIPTION
## Summary

- Update `early_stop_patience` default from `3000L` to `10000L` across all 4 model estimators and `create_early_stop_config()`
- Update `early_stop_max_evals` default from `50000L` to `60000L` across all 4 model estimators and `create_early_stop_config()`
- Update test assertion to match new defaults

## Calibration basis

Post-fix calibration (with #34 clamp fix active) on real Liu-Wu yield data, K=3, off-diagonal, unequal variances, 20 starts x 3 maturities:

| Metric | Converged starts |
|--------|-----------------|
| Count | 35/60 (58%) |
| Median evals | 5,569 |
| Q75 evals | 7,999 |
| Max evals | 42,491 |
| Early-stopped (at 50k) | 6/60 |

Previous `patience=3000` was calibrated before #34 when most exo starts errored out, making the exo data unreliable. With the fix, converged exo starts need a median of 5,569 evals — `patience=3000` would prematurely kill many of them.

## Merge note

This branch diverges from main before PR #37 (B/C → n_burnin/n_cutoff rename). Merge conflicts will be limited to the function signature lines — resolve by taking main's parameter names with this branch's default values.

## Test plan

- [x] Early stopping default assertion updated
- [x] Changes are default-value-only, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)