### PR TITLE
test: slim down test suite and enable parallel (#38)

### DIFF
--- a/tests/testthat/test-convergence-diagnostics.R
+++ b/tests/testthat/test-convergence-diagnostics.R
@@ -507,11 +507,11 @@ test_that("GAS K=3 off-diagonal single-start attempts optimization", {
 test_that("TVP K=2 off-diagonal estimation converges on synthetic data", {
   skip_on_cran()
   set.seed(100)
-  y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
+  y <- c(rnorm(150, -1, 0.5), rnorm(150, 1, 0.7))
 
   result <- estimate_tvp_model(
     y, K = 2, diag_probs = FALSE, equal_variances = TRUE,
-    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
+    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -522,13 +522,13 @@ test_that("TVP K=2 off-diagonal estimation converges on synthetic data", {
 test_that("exogenous K=2 off-diagonal estimation converges on synthetic data", {
   skip_on_cran()
   set.seed(100)
-  y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
+  y <- c(rnorm(150, -1, 0.5), rnorm(150, 1, 0.7))
   X_Exo <- rnorm(length(y))
 
   # With logistic link, exogenous K=2 off-diagonal should converge
   result <- estimate_exo_model(
     y, X_Exo = X_Exo, K = 2, diag_probs = FALSE, equal_variances = TRUE,
-    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
+    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -539,11 +539,11 @@ test_that("exogenous K=2 off-diagonal estimation converges on synthetic data", {
 test_that("GAS K=2 off-diagonal estimation converges on synthetic data", {
   skip_on_cran()
   set.seed(100)
-  y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
+  y <- c(rnorm(150, -1, 0.5), rnorm(150, 1, 0.7))
 
   result <- estimate_gas_model(
     y, K = 2, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE,
+    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0,
     use_fallback = TRUE
   )
 
@@ -563,11 +563,11 @@ test_that("GAS K=2 off-diagonal estimation converges on synthetic data", {
 test_that("TVP K=3 off-diagonal unequal-var estimation converges", {
   skip_on_cran()
   set.seed(42)
-  y <- c(rnorm(200, -2, sqrt(0.5)), rnorm(200, 0, 1), rnorm(200, 2, sqrt(1.5)))
+  y <- c(rnorm(135, -2, sqrt(0.5)), rnorm(135, 0, 1), rnorm(130, 2, sqrt(1.5)))
 
   result <- estimate_tvp_model(
     y, K = 3, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
+    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -577,12 +577,12 @@ test_that("TVP K=3 off-diagonal unequal-var estimation converges", {
 test_that("exogenous K=3 off-diagonal unequal-var estimation converges", {
   skip_on_cran()
   set.seed(42)
-  y <- c(rnorm(200, -2, sqrt(0.5)), rnorm(200, 0, 1), rnorm(200, 2, sqrt(1.5)))
+  y <- c(rnorm(135, -2, sqrt(0.5)), rnorm(135, 0, 1), rnorm(130, 2, sqrt(1.5)))
   X_Exo <- rnorm(length(y))
 
   result <- estimate_exo_model(
     y, X_Exo = X_Exo, K = 3, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE
+    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0
   )
 
   expect_true(is.finite(result$diagnostics$neg_log_likelihood),
@@ -592,11 +592,11 @@ test_that("exogenous K=3 off-diagonal unequal-var estimation converges", {
 test_that("GAS K=3 off-diagonal unequal-var estimation converges", {
   skip_on_cran()
   set.seed(42)
-  y <- c(rnorm(200, -2, sqrt(0.5)), rnorm(200, 0, 1), rnorm(200, 2, sqrt(1.5)))
+  y <- c(rnorm(135, -2, sqrt(0.5)), rnorm(135, 0, 1), rnorm(130, 2, sqrt(1.5)))
 
   result <- estimate_gas_model(
     y, K = 3, diag_probs = FALSE, equal_variances = FALSE,
-    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0, parallel = FALSE,
+    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0,
     use_fallback = TRUE
   )
 
@@ -655,7 +655,7 @@ test_that("exogenous filter K=3 off-diagonal with large A and wide X_Exo returns
                                   diag_probs = FALSE, equal_variances = FALSE)
 
   # Before the fix, this would error with "Transition matrix contains negative values"
-  nll <- Rfiltering_TVPXExo(par, X_Exo, y, B = 20, C = 10)
+  nll <- Rfiltering_TVPXExo(par, X_Exo, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll), info = paste("NLL was:", nll))
 })
 
@@ -671,6 +671,6 @@ test_that("TVP filter K=3 off-diagonal with large A returns finite NLL (issue #3
   par <- set_parameter_attributes(par, K = 3, model_type = "tvp",
                                   diag_probs = FALSE, equal_variances = FALSE)
 
-  nll <- Rfiltering_TVP(par, y, B = 20, C = 10)
+  nll <- Rfiltering_TVP(par, y, n_burnin = 20, n_cutoff = 10)
   expect_true(is.finite(nll), info = paste("NLL was:", nll))
 })

--- a/tests/testthat/test-early-stopping.R
+++ b/tests/testthat/test-early-stopping.R
@@ -155,8 +155,7 @@ test_that("constant model estimation works with early stopping enabled", {
 
   # Use generous thresholds to avoid prematurely stopping all starts
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 3, n_burnin = 20, n_cutoff = 10, verbose = 0,
-                                    parallel = FALSE,
+                                    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                     early_stopping = TRUE,
                                     early_stop_patience = 5000,
                                     early_stop_max_evals = 500000)
@@ -174,8 +173,7 @@ test_that("early_stopping=FALSE preserves backward compatibility", {
   y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
 
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 2, n_burnin = 20, n_cutoff = 10, verbose = 0,
-                                    parallel = FALSE,
+                                    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                     early_stopping = FALSE)
 
   # New fields should exist but with zero/FALSE values
@@ -195,8 +193,7 @@ test_that("early-stopped runs never win best-result selection", {
 
   # Use enough starts and generous enough thresholds that at least one converges
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 5, n_burnin = 20, n_cutoff = 10, verbose = 0,
-                                    parallel = FALSE,
+                                    n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                     early_stopping = TRUE,
                                     early_stop_patience = 5000,
                                     early_stop_max_evals = 500000)
@@ -219,8 +216,7 @@ test_that("TVP model estimation works with early stopping", {
   y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
 
   result <- estimate_tvp_model(y, K = 2, diag_probs = FALSE,
-                               n_starts = 2, n_burnin = 20, n_cutoff = 10, verbose = 0,
-                               parallel = FALSE,
+                               n_starts = 4, n_burnin = 20, n_cutoff = 10, verbose = 0,
                                early_stopping = TRUE,
                                early_stop_patience = 5000,
                                early_stop_max_evals = 500000)

--- a/tests/testthat/test-gas-fallback.R
+++ b/tests/testthat/test-gas-fallback.R
@@ -1,6 +1,6 @@
 # tests/testthat/test-gas-fallback.R
 #
-# Comprehensive tests for the GAS model fallback-to-constant mechanism.
+# Tests for the GAS model fallback-to-constant mechanism.
 # When max(|A|) < A_threshold, Rfiltering_GAS() delegates to Rfiltering_Const()
 # instead of running full GAS score-driven filtering.
 
@@ -44,30 +44,26 @@ describe("GAS fallback triggering", {
     expect_equal(gas_diag$model_type, "full_gas")
   })
 
-  it("triggers fallback when A is just below threshold boundary", {
+  it("boundary behavior: just-below triggers, exactly-at does not (strict less-than)", {
     # max(|A|) = 9.999e-5 < 1e-4 => fallback
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 9.999e-5, 5e-5, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
+    gas_par_below <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 9.999e-5, 5e-5, 0.85, 0.90)
+    gas_par_below <- set_parameter_attributes(gas_par_below, K = 2, model_type = "gas",
+                                              diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                             use_fallback = TRUE, A_threshold = 1e-4,
-                             diagnostics = TRUE)
+    result_below <- Rfiltering_GAS(gas_par_below, y_data, n_burnin, C_cutoff,
+                                   use_fallback = TRUE, A_threshold = 1e-4,
+                                   diagnostics = TRUE)
+    expect_equal(attr(result_below, "model_type"), "constant_fallback")
 
-    expect_equal(attr(result, "model_type"), "constant_fallback")
-  })
-
-  it("does NOT trigger fallback when A is exactly at threshold (strict less-than)", {
     # max(|A|) = 1e-4, which is NOT < 1e-4 => full GAS
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-4, 5e-5, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
+    gas_par_at <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-4, 5e-5, 0.85, 0.90)
+    gas_par_at <- set_parameter_attributes(gas_par_at, K = 2, model_type = "gas",
+                                           diag_probs = TRUE, equal_variances = FALSE)
 
-    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                             use_fallback = TRUE, A_threshold = 1e-4,
-                             diagnostics = TRUE)
-
-    gas_diag <- attr(result, "gas_diagnostics")
+    result_at <- Rfiltering_GAS(gas_par_at, y_data, n_burnin, C_cutoff,
+                                use_fallback = TRUE, A_threshold = 1e-4,
+                                diagnostics = TRUE)
+    gas_diag <- attr(result_at, "gas_diagnostics")
     expect_equal(gas_diag$model_type, "full_gas")
   })
 
@@ -86,37 +82,33 @@ describe("GAS fallback triggering", {
     expect_true(is.finite(result))
   })
 
-  it("respects custom larger A_threshold", {
-    # A = 0.05, default threshold 1e-4 would NOT trigger, but threshold=0.1 triggers
+  it("respects custom A_threshold in both directions", {
+    # A = 0.05: default threshold 1e-4 would NOT trigger, but threshold=0.1 triggers
     gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 0.05, 0.03, 0.85, 0.90)
     gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    # Default threshold: should NOT trigger fallback
     result_default <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                      use_fallback = TRUE, A_threshold = 1e-4,
                                      diagnostics = TRUE)
     expect_null(attr(result_default, "model_type"))
 
-    # Large custom threshold: SHOULD trigger fallback
     result_custom <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
                                     use_fallback = TRUE, A_threshold = 0.1,
                                     diagnostics = TRUE)
     expect_equal(attr(result_custom, "model_type"), "constant_fallback")
-  })
 
-  it("respects custom smaller A_threshold", {
     # A = 1e-6: default threshold 1e-4 triggers, but threshold 1e-8 does NOT
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-6, 5e-7, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
+    gas_par2 <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-6, 5e-7, 0.85, 0.90)
+    gas_par2 <- set_parameter_attributes(gas_par2, K = 2, model_type = "gas",
+                                         diag_probs = TRUE, equal_variances = FALSE)
 
-    result_default <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                     use_fallback = TRUE, A_threshold = 1e-4,
-                                     diagnostics = TRUE)
-    expect_equal(attr(result_default, "model_type"), "constant_fallback")
+    result_default2 <- Rfiltering_GAS(gas_par2, y_data, n_burnin, C_cutoff,
+                                      use_fallback = TRUE, A_threshold = 1e-4,
+                                      diagnostics = TRUE)
+    expect_equal(attr(result_default2, "model_type"), "constant_fallback")
 
-    result_small <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
+    result_small <- Rfiltering_GAS(gas_par2, y_data, n_burnin, C_cutoff,
                                    use_fallback = TRUE, A_threshold = 1e-8,
                                    diagnostics = TRUE)
     gas_diag <- attr(result_small, "gas_diagnostics")
@@ -155,28 +147,6 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
                                      diagnostics = FALSE)
 
     # Exactly identical (same code path via delegation)
-    expect_equal(as.numeric(gas_result), as.numeric(const_result))
-  })
-
-  it("produces identical likelihood for K=2 diagonal with all-zero A", {
-    mu1 <- -0.5; mu2 <- 0.5
-    sigma2_1 <- 0.3; sigma2_2 <- 0.4
-    p11 <- 0.7; p22 <- 0.85
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 250, const_par, burn_in = 100)[1, ]
-
-    gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, 0, 0, 0.9, 0.9)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                 use_fallback = TRUE, diagnostics = FALSE)
-    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
-                                     diagnostics = FALSE)
-
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
   })
 
@@ -224,31 +194,6 @@ describe("GAS fallback likelihood equivalence with direct constant model", {
                                      diagnostics = FALSE)
 
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
-  })
-
-  it("produces identical filtered probabilities under diagnostics", {
-    mu1 <- -1; mu2 <- 1
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
-    p11 <- 0.8; p22 <- 0.9
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 200, const_par, burn_in = 100)[1, ]
-
-    gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, 1e-9, 1e-9, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                 use_fallback = TRUE, diagnostics = TRUE)
-    const_result <- Rfiltering_Const(const_par, y_data, n_burnin, C_cutoff,
-                                     diagnostics = TRUE)
-
-    expect_equal(attr(gas_result, "X.t"), attr(const_result, "X.t"))
-    expect_equal(attr(gas_result, "X.tlag"), attr(const_result, "X.tlag"))
-    expect_equal(attr(gas_result, "eta"), attr(const_result, "eta"))
-    expect_equal(attr(gas_result, "tot.lik"), attr(const_result, "tot.lik"))
   })
 
   it("produces identical likelihood for K=3 diagonal parameterization", {
@@ -492,7 +437,7 @@ describe("GAS fallback edge cases", {
     expect_equal(nrow(f_matrix), 3)
   })
 
-  it("works correctly with K=3 off-diagonal model and matches constant likelihood", {
+  it("handles K=3 off-diagonal model correctly", {
     # K=3 off-diagonal: 6 transition params
     const_par_k3_od <- c(-2, 0, 2, 0.4, 0.5, 0.6,
                           0.1, 0.1, 0.15, 0.15, 0.08, 0.07)
@@ -522,36 +467,6 @@ describe("GAS fallback edge cases", {
                                      diagnostics = FALSE)
     expect_equal(as.numeric(gas_result), as.numeric(const_result))
   })
-
-  it("handles mixed sign A values all below threshold", {
-    y_data <- rnorm(300)
-
-    # A = c(3e-5, -8e-5) => max(abs) = 8e-5 < 1e-4 => fallback
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 3e-5, -8e-5, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                             use_fallback = TRUE, A_threshold = 1e-4,
-                             diagnostics = TRUE)
-
-    expect_equal(attr(result, "model_type"), "constant_fallback")
-    expect_equal(attr(result, "max_A"), 8e-5)
-  })
-
-  it("returns finite likelihood for very short time series", {
-    y_short <- rnorm(50)
-
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    result <- Rfiltering_GAS(gas_par, y_short, n_burnin = 5, n_cutoff = 0,
-                             use_fallback = TRUE, diagnostics = FALSE)
-
-    expect_true(is.numeric(result))
-    expect_true(is.finite(result))
-  })
 })
 
 # =============================================================================
@@ -574,7 +489,7 @@ describe("GAS fallback integration with estimate_gas_model", {
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
       n_starts = 1, n_burnin = 20, n_cutoff = 0,
       use_fallback = TRUE, A_threshold = 1e-4,
-      parallel = FALSE, verbose = 0, seed = 42
+      verbose = 0, seed = 42
     )
 
     # model_info should exist with model_type_used
@@ -603,7 +518,7 @@ describe("GAS fallback integration with estimate_gas_model", {
       y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
       n_starts = 1, n_burnin = 20, n_cutoff = 0,
       use_fallback = FALSE,
-      parallel = FALSE, verbose = 0, seed = 42
+      verbose = 0, seed = 42
     )
 
     # With use_fallback=FALSE, model_type_used must be full_gas
@@ -623,12 +538,6 @@ describe("GAS fallback integration with estimate_gas_model", {
 
 describe("Full GAS vs constant fallback accuracy with near-zero A", {
   skip_on_cran()
-
-  # NOTE: The full GAS path and constant fallback use DIFFERENT initialization.
-  # The GAS model computes initial predicted probabilities via logistic(logit(.))
-  # and a different X_t[,1] computation, while the constant model uses the
-  # stationary distribution directly. This causes small but measurable
-  # likelihood differences even when A is effectively zero.
 
   set.seed(2024)
   n_burnin <- 20
@@ -658,30 +567,6 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
 
     # Likelihoods should be close (different code paths but A ~ 0)
     # Allow up to 1% relative difference due to initialization differences
-    expect_equal(as.numeric(full_gas_result), as.numeric(fallback_result),
-                 tolerance = 0.01)
-  })
-
-  it("likelihood is nearly identical for K=2 diagonal with zero A and zero B", {
-    mu1 <- -1; mu2 <- 1
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
-    p11 <- 0.8; p22 <- 0.9
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 500, const_par, burn_in = 100)[1, ]
-
-    # A=0, B=0: GAS dynamics completely inactive
-    gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, 0, 0, 0, 0)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    full_gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                      use_fallback = FALSE, diagnostics = FALSE)
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                      use_fallback = TRUE, diagnostics = FALSE)
-
     expect_equal(as.numeric(full_gas_result), as.numeric(fallback_result),
                  tolerance = 0.01)
   })
@@ -742,298 +627,7 @@ describe("Full GAS vs constant fallback accuracy with near-zero A", {
     if (!is.null(full_gas_result)) {
       expect_equal(as.numeric(full_gas_result), as.numeric(fallback_result),
                    tolerance = 0.01)
-    } else {
-      # Full GAS failed numerically — this is exactly why fallback exists!
-      message("  K=3 full GAS hit numerical error; fallback provides stable result")
     }
-  })
-
-  it("filtered probabilities converge after burn-in with tiny A", {
-    mu1 <- -1; mu2 <- 1
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
-    p11 <- 0.8; p22 <- 0.9
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 300, const_par, burn_in = 100)[1, ]
-
-    gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    full_gas_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                      use_fallback = FALSE, diagnostics = TRUE)
-    fallback_result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                      use_fallback = TRUE, diagnostics = TRUE)
-
-    # The two paths use different initialization and indexing conventions.
-    # The GAS model's X.t is offset by 1 relative to the constant model's
-    # (different initial state handling). Rather than comparing element-wise,
-    # verify that both produce valid probability matrices that agree on the
-    # regime classification for the vast majority of time steps.
-    full_Xt <- attr(full_gas_result, "X.t")
-    fb_Xt <- attr(fallback_result, "X.t")
-    expect_equal(dim(full_Xt), dim(fb_Xt))
-
-    # Both should produce valid probabilities (each column sums to ~1)
-    full_colsums <- colSums(full_Xt)
-    fb_colsums <- colSums(fb_Xt)
-    expect_true(all(abs(full_colsums - 1) < 0.01))
-    expect_true(all(abs(fb_colsums - 1) < 0.01))
-
-    # After burn-in, regime classifications should mostly agree
-    # (which regime has highest probability at each time step)
-    post_burnin <- (n_burnin + 5):ncol(full_Xt)
-    full_regime <- apply(full_Xt[, post_burnin], 2, which.max)
-    fb_regime <- apply(fb_Xt[, post_burnin], 2, which.max)
-    agreement_rate <- mean(full_regime == fb_regime)
-    # The two code paths use different initialization (GAS uses logistic(logit(.))
-    # while constant uses stationary distribution directly), so perfect agreement
-    # is not expected. The key insight is that with A~0, the regime classifications
-    # should substantially agree.
-    expect_true(agreement_rate > 0.80,
-                label = sprintf("Regime agreement rate %.1f%% should be > 80%%",
-                                agreement_rate * 100))
-    message(sprintf("  Regime agreement rate: %.1f%%", agreement_rate * 100))
-  })
-
-  it("accuracy degrades gracefully as A increases toward threshold", {
-    mu1 <- -1; mu2 <- 1
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
-    p11 <- 0.8; p22 <- 0.9
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 500, const_par, burn_in = 100)[1, ]
-
-    # Compare at different A magnitudes
-    A_levels <- c(1e-10, 1e-8, 1e-6, 1e-5)
-    diffs <- numeric(length(A_levels))
-
-    for (i in seq_along(A_levels)) {
-      a <- A_levels[i]
-      gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, a, a, 0.85, 0.90)
-      gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-
-      full_gas <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                 use_fallback = FALSE, diagnostics = FALSE)
-      fallback <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                 use_fallback = TRUE, diagnostics = FALSE)
-
-      diffs[i] <- abs(as.numeric(full_gas) - as.numeric(fallback))
-    }
-
-    # All differences should be small relative to the likelihood magnitude
-    expect_true(all(diffs < 5),
-                label = "All likelihood differences should be small")
-
-    # Report the differences for informational purposes
-    for (i in seq_along(A_levels)) {
-      message(sprintf("  A=%.0e: diff=%.6f", A_levels[i], diffs[i]))
-    }
-  })
-})
-
-# =============================================================================
-# CATEGORY 7: Performance — Fallback Should Be Faster Than Full GAS
-# =============================================================================
-#
-# The constant model fallback avoids Gauss-Hermite quadrature, score
-# calculation, and Fisher information computation. It should be substantially
-# faster than the full GAS path, especially for longer time series and more
-# regimes.
-
-describe("Fallback performance advantage over full GAS", {
-  skip_on_cran()
-
-  n_burnin <- 20
-  C_cutoff <- 0
-
-  it("fallback is faster than full GAS for K=2 N=1000", {
-    set.seed(3001)
-    y_data <- rnorm(1000)
-
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    # Time the fallback path (multiple runs for stability)
-    n_reps <- 5
-    time_fallback <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                       use_fallback = TRUE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    # Time the full GAS path
-    time_full_gas <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                       use_fallback = FALSE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    # Fallback should be faster (or at worst comparable)
-    # We use a generous margin: fallback time < full GAS time * 1.1
-    # (allow 10% slack for system noise)
-    expect_true(time_fallback < time_full_gas * 1.1,
-                label = sprintf("Fallback (%.4fs) should be faster than full GAS (%.4fs)",
-                                time_fallback, time_full_gas))
-
-    # Report the speedup for informational purposes
-    if (time_fallback > 0) {
-      speedup <- time_full_gas / time_fallback
-      message(sprintf("  K=2 N=1000: fallback=%.4fs, full_gas=%.4fs, speedup=%.1fx",
-                      time_fallback, time_full_gas, speedup))
-    }
-  })
-
-  it("fallback is faster than full GAS for K=2 N=2000", {
-    set.seed(3002)
-    y_data <- rnorm(2000)
-
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    n_reps <- 3
-    time_fallback <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                       use_fallback = TRUE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    time_full_gas <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                       use_fallback = FALSE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    expect_true(time_fallback < time_full_gas * 1.1,
-                label = sprintf("Fallback (%.4fs) should be faster than full GAS (%.4fs)",
-                                time_fallback, time_full_gas))
-
-    if (time_fallback > 0) {
-      speedup <- time_full_gas / time_fallback
-      message(sprintf("  K=2 N=2000: fallback=%.4fs, full_gas=%.4fs, speedup=%.1fx",
-                      time_fallback, time_full_gas, speedup))
-    }
-  })
-
-  it("speedup increases with longer time series", {
-    set.seed(3003)
-
-    gas_par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    series_lengths <- c(500, 2000)
-    speedups <- numeric(length(series_lengths))
-    n_reps <- 3
-
-    for (j in seq_along(series_lengths)) {
-      N <- series_lengths[j]
-      y_data <- rnorm(N)
-
-      time_fallback <- system.time({
-        for (i in seq_len(n_reps)) {
-          Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                         use_fallback = TRUE, diagnostics = FALSE)
-        }
-      })["elapsed"]
-
-      time_full_gas <- system.time({
-        for (i in seq_len(n_reps)) {
-          Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                         use_fallback = FALSE, diagnostics = FALSE)
-        }
-      })["elapsed"]
-
-      # Ensure both ran for a measurable time
-      speedups[j] <- if (time_fallback > 0) time_full_gas / time_fallback else Inf
-
-      message(sprintf("  N=%d: fallback=%.4fs, full_gas=%.4fs, speedup=%.1fx",
-                      N, time_fallback, time_full_gas, speedups[j]))
-    }
-
-    # Fallback should always be faster
-    expect_true(all(speedups > 0.9),
-                label = "Fallback should be at least as fast for all series lengths")
-
-    # The speedup for the longer series should be >= the shorter one
-    # (GAS overhead scales with N, constant model is simpler)
-    # Use a generous margin to account for system noise.
-    # When fallback time is 0 (too fast to measure), speedup is Inf;
-    # in that case skip the comparison since both are "instant".
-    if (is.finite(speedups[1]) && is.finite(speedups[2])) {
-      expect_true(speedups[2] >= speedups[1] * 0.5,
-                  label = sprintf("Speedup should scale with N (N=500: %.1fx, N=2000: %.1fx)",
-                                  speedups[1], speedups[2]))
-    }
-  })
-
-  it("fallback speedup is consistent across parameterizations", {
-    set.seed(3004)
-    y_data <- rnorm(1000)
-    n_reps <- 3
-
-    # K=2 diagonal (2 A + 2 B = 4 time-varying params)
-    gas_par_diag <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par_diag <- set_parameter_attributes(gas_par_diag, K = 2, model_type = "gas",
-                                             diag_probs = TRUE, equal_variances = FALSE)
-
-    time_fb_diag <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_diag, y_data, n_burnin, C_cutoff,
-                       use_fallback = TRUE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    time_gas_diag <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_diag, y_data, n_burnin, C_cutoff,
-                       use_fallback = FALSE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    # K=2 off-diagonal (2 A + 2 B = 4 time-varying params, but different scaling)
-    gas_par_offdiag <- c(-1, 1, 0.5, 0.6, 0.2, 0.1, 1e-8, 1e-8, 0.85, 0.90)
-    gas_par_offdiag <- set_parameter_attributes(gas_par_offdiag, K = 2, model_type = "gas",
-                                                diag_probs = FALSE, equal_variances = FALSE)
-
-    time_fb_offdiag <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_offdiag, y_data, n_burnin, C_cutoff,
-                       use_fallback = TRUE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    time_gas_offdiag <- system.time({
-      for (i in seq_len(n_reps)) {
-        Rfiltering_GAS(gas_par_offdiag, y_data, n_burnin, C_cutoff,
-                       use_fallback = FALSE, diagnostics = FALSE)
-      }
-    })["elapsed"]
-
-    speedup_diag <- if (time_fb_diag > 0) time_gas_diag / time_fb_diag else Inf
-    speedup_offdiag <- if (time_fb_offdiag > 0) time_gas_offdiag / time_fb_offdiag else Inf
-
-    message(sprintf("  Diagonal:     fallback=%.4fs, full_gas=%.4fs, speedup=%.1fx",
-                    time_fb_diag, time_gas_diag, speedup_diag))
-    message(sprintf("  Off-diagonal: fallback=%.4fs, full_gas=%.4fs, speedup=%.1fx",
-                    time_fb_offdiag, time_gas_offdiag, speedup_offdiag))
-
-    # Both parameterizations should show speedup
-    expect_true(speedup_diag > 0.9,
-                label = "Diagonal fallback should be at least as fast")
-    expect_true(speedup_offdiag > 0.9,
-                label = "Off-diagonal fallback should be at least as fast")
   })
 })
 
@@ -1085,50 +679,6 @@ describe("B-coefficient irrelevance under fallback", {
                                 use_fallback = TRUE, diagnostics = FALSE)
 
     expect_identical(as.numeric(result_1), as.numeric(result_2))
-  })
-
-  it("varying B produces identical diagnostics under fallback", {
-    make_gas_par <- function(B1, B2) {
-      par <- c(-1, 1, 0.5, 0.6, 0.8, 0.9, 1e-8, 1e-8, B1, B2)
-      set_parameter_attributes(par, K = 2, model_type = "gas",
-                               diag_probs = TRUE, equal_variances = FALSE)
-    }
-
-    result_1 <- Rfiltering_GAS(make_gas_par(0.1, 0.1), y_data, n_burnin, C_cutoff,
-                                use_fallback = TRUE, diagnostics = TRUE)
-    result_2 <- Rfiltering_GAS(make_gas_par(0.99, 0.99), y_data, n_burnin, C_cutoff,
-                                use_fallback = TRUE, diagnostics = TRUE)
-
-    expect_identical(attr(result_1, "X.t"), attr(result_2, "X.t"))
-    expect_identical(attr(result_1, "X.tlag"), attr(result_2, "X.tlag"))
-    expect_identical(attr(result_1, "eta"), attr(result_2, "eta"))
-    expect_identical(attr(result_1, "tot.lik"), attr(result_2, "tot.lik"))
-    expect_identical(attr(result_1, "score_scaled"), attr(result_2, "score_scaled"))
-    expect_identical(attr(result_1, "gas_diagnostics"), attr(result_2, "gas_diagnostics"))
-  })
-
-  it("varying B produces identical likelihood for K=3 diagonal", {
-    const_par_k3 <- c(-2, 0, 2, 0.4, 0.5, 0.6, 0.8, 0.7, 0.85)
-    const_par_k3 <- set_parameter_attributes(const_par_k3, K = 3, model_type = "constant",
-                                             diag_probs = TRUE, equal_variances = FALSE)
-    y_k3 <- dataConstCD(1, 400, const_par_k3, burn_in = 100)[1, ]
-
-    make_gas_k3 <- function(B1, B2, B3) {
-      par <- c(-2, 0, 2, 0.4, 0.5, 0.6, 0.8, 0.7, 0.85,
-               1e-8, 1e-8, 1e-8, B1, B2, B3)
-      set_parameter_attributes(par, K = 3, model_type = "gas",
-                               diag_probs = TRUE, equal_variances = FALSE)
-    }
-
-    result_1 <- Rfiltering_GAS(make_gas_k3(0.1, 0.1, 0.1), y_k3, n_burnin, C_cutoff,
-                                use_fallback = TRUE, diagnostics = FALSE)
-    result_2 <- Rfiltering_GAS(make_gas_k3(0.5, 0.5, 0.5), y_k3, n_burnin, C_cutoff,
-                                use_fallback = TRUE, diagnostics = FALSE)
-    result_3 <- Rfiltering_GAS(make_gas_k3(0.99, 0.99, 0.99), y_k3, n_burnin, C_cutoff,
-                                use_fallback = TRUE, diagnostics = FALSE)
-
-    expect_identical(as.numeric(result_1), as.numeric(result_2))
-    expect_identical(as.numeric(result_2), as.numeric(result_3))
   })
 })
 
@@ -1233,16 +783,6 @@ describe("Fallback parameter construction correctness", {
     expect_equal(nrow(Xt), 2)  # K=2
     expect_equal(ncol(Xt), 300)  # length(y_data)
   })
-
-  it("extract_parameter_component returns length 1 sigma2 for equal_variances=TRUE", {
-    gas_par <- c(-1, 1, 0.5, 0.8, 0.9, 0.1, 0.1, 0.85, 0.9)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = TRUE)
-
-    sigma2 <- extract_parameter_component(gas_par, "sigma2")
-    expect_equal(length(sigma2), 1)
-    expect_equal(sigma2, 0.5)
-  })
 })
 
 # =============================================================================
@@ -1320,28 +860,6 @@ describe("Fallback numerical stability at parameter extremes", {
     expect_true(is.numeric(result))
     expect_true(is.finite(result))
   })
-
-  it("handles identical means with different variances", {
-    gas_par <- c(0, 0, 0.5, 0.6, 0.8, 0.9, 0, 0, 0.5, 0.5)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                              use_fallback = TRUE, diagnostics = FALSE)
-    expect_true(is.numeric(result))
-    expect_true(is.finite(result))
-  })
-
-  it("handles fully degenerate case (identical means and variances)", {
-    gas_par <- c(0, 0, 0.5, 0.5, 0.8, 0.9, 0, 0, 0.5, 0.5)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-
-    result <- Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                              use_fallback = TRUE, diagnostics = FALSE)
-    expect_true(is.numeric(result))
-    expect_true(is.finite(result))
-  })
 })
 
 # =============================================================================
@@ -1358,7 +876,7 @@ describe("Likelihood surface continuity at A_threshold boundary", {
   n_burnin <- 20
   C_cutoff <- 0
 
-  it("likelihood is nearly identical just below vs just above threshold (K=2 diagonal)", {
+  it("likelihood is nearly identical just below vs just above threshold (K=2)", {
     mu1 <- -1; mu2 <- 1
     sigma2_1 <- 0.5; sigma2_2 <- 0.6
     p11 <- 0.8; p22 <- 0.9
@@ -1368,12 +886,11 @@ describe("Likelihood surface continuity at A_threshold boundary", {
                                           diag_probs = TRUE, equal_variances = FALSE)
     y_data <- dataConstCD(1, 500, const_par, burn_in = 100)[1, ]
 
-    # A just below threshold: triggers fallback
+    # Diagonal parameterization
     gas_par_below <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, 9.99e-5, 9.99e-5, 0.85, 0.90)
     gas_par_below <- set_parameter_attributes(gas_par_below, K = 2, model_type = "gas",
                                               diag_probs = TRUE, equal_variances = FALSE)
 
-    # A just above threshold: full GAS
     gas_par_above <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, 1.01e-4, 1.01e-4, 0.85, 0.90)
     gas_par_above <- set_parameter_attributes(gas_par_above, K = 2, model_type = "gas",
                                               diag_probs = TRUE, equal_variances = FALSE)
@@ -1383,77 +900,33 @@ describe("Likelihood surface continuity at A_threshold boundary", {
     nll_above <- Rfiltering_GAS(gas_par_above, y_data, n_burnin, C_cutoff,
                                  use_fallback = TRUE, diagnostics = FALSE)
 
-    # Relative difference should be small (< 0.1%)
     rel_diff <- abs(as.numeric(nll_below) - as.numeric(nll_above)) / abs(as.numeric(nll_below))
     expect_true(rel_diff < 0.001,
                 label = sprintf("Relative NLL difference at boundary: %.6f (should be < 0.001)", rel_diff))
-  })
 
-  it("likelihood is nearly identical just below vs just above threshold (K=2 off-diagonal)", {
-    mu1 <- -1; mu2 <- 1
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
+    # Off-diagonal parameterization
     p12 <- 0.2; p21 <- 0.1
+    const_par_od <- c(mu1, mu2, sigma2_1, sigma2_2, p12, p21)
+    const_par_od <- set_parameter_attributes(const_par_od, K = 2, model_type = "constant",
+                                             diag_probs = FALSE, equal_variances = FALSE)
+    y_data_od <- dataConstCD(1, 500, const_par_od, burn_in = 100)[1, ]
 
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p12, p21)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = FALSE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 500, const_par, burn_in = 100)[1, ]
+    gas_par_below_od <- c(mu1, mu2, sigma2_1, sigma2_2, p12, p21, 9.99e-5, 9.99e-5, 0.85, 0.90)
+    gas_par_below_od <- set_parameter_attributes(gas_par_below_od, K = 2, model_type = "gas",
+                                                 diag_probs = FALSE, equal_variances = FALSE)
 
-    gas_par_below <- c(mu1, mu2, sigma2_1, sigma2_2, p12, p21, 9.99e-5, 9.99e-5, 0.85, 0.90)
-    gas_par_below <- set_parameter_attributes(gas_par_below, K = 2, model_type = "gas",
-                                              diag_probs = FALSE, equal_variances = FALSE)
+    gas_par_above_od <- c(mu1, mu2, sigma2_1, sigma2_2, p12, p21, 1.01e-4, 1.01e-4, 0.85, 0.90)
+    gas_par_above_od <- set_parameter_attributes(gas_par_above_od, K = 2, model_type = "gas",
+                                                 diag_probs = FALSE, equal_variances = FALSE)
 
-    gas_par_above <- c(mu1, mu2, sigma2_1, sigma2_2, p12, p21, 1.01e-4, 1.01e-4, 0.85, 0.90)
-    gas_par_above <- set_parameter_attributes(gas_par_above, K = 2, model_type = "gas",
-                                              diag_probs = FALSE, equal_variances = FALSE)
+    nll_below_od <- Rfiltering_GAS(gas_par_below_od, y_data_od, n_burnin, C_cutoff,
+                                    use_fallback = TRUE, diagnostics = FALSE)
+    nll_above_od <- Rfiltering_GAS(gas_par_above_od, y_data_od, n_burnin, C_cutoff,
+                                    use_fallback = TRUE, diagnostics = FALSE)
 
-    nll_below <- Rfiltering_GAS(gas_par_below, y_data, n_burnin, C_cutoff,
-                                 use_fallback = TRUE, diagnostics = FALSE)
-    nll_above <- Rfiltering_GAS(gas_par_above, y_data, n_burnin, C_cutoff,
-                                 use_fallback = TRUE, diagnostics = FALSE)
-
-    rel_diff <- abs(as.numeric(nll_below) - as.numeric(nll_above)) / abs(as.numeric(nll_below))
-    expect_true(rel_diff < 0.001,
-                label = sprintf("Relative NLL difference at boundary: %.6f (should be < 0.001)", rel_diff))
-  })
-
-  it("A sweep produces finite NLLs and small boundary jump", {
-    mu1 <- -1; mu2 <- 1
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
-    p11 <- 0.8; p22 <- 0.9
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 500, const_par, burn_in = 100)[1, ]
-
-    A_values <- c(1e-5, 5e-5, 9.9e-5, 1.0e-4, 5e-4, 1e-3)
-    nlls <- numeric(length(A_values))
-
-    for (i in seq_along(A_values)) {
-      a <- A_values[i]
-      gas_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22, a, a, 0.85, 0.90)
-      gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-      nlls[i] <- as.numeric(Rfiltering_GAS(gas_par, y_data, n_burnin, C_cutoff,
-                                            use_fallback = TRUE, diagnostics = FALSE))
-    }
-
-    # All NLLs should be finite
-    expect_true(all(is.finite(nlls)),
-                label = "All NLLs in sweep should be finite")
-
-    # The jump at the boundary (between index 3 and 4: 9.9e-5 -> 1.0e-4)
-    # should be small relative to the overall range
-    boundary_jump <- abs(nlls[4] - nlls[3])
-    max_diff <- max(abs(diff(nlls)))
-    expect_true(boundary_jump < max_diff * 2,
-                label = sprintf("Boundary jump (%.6f) should be comparable to other diffs (max %.6f)",
-                                boundary_jump, max_diff))
-
-    for (i in seq_along(A_values)) {
-      message(sprintf("  A=%.1e: NLL=%.6f", A_values[i], nlls[i]))
-    }
+    rel_diff_od <- abs(as.numeric(nll_below_od) - as.numeric(nll_above_od)) / abs(as.numeric(nll_below_od))
+    expect_true(rel_diff_od < 0.001,
+                label = sprintf("Off-diagonal boundary rel diff: %.6f (should be < 0.001)", rel_diff_od))
   })
 
   it("likelihood is nearly identical at boundary for K=3 diagonal", {
@@ -1490,275 +963,7 @@ describe("Likelihood surface continuity at A_threshold boundary", {
       rel_diff <- abs(as.numeric(nll_below) - as.numeric(nll_above)) / abs(as.numeric(nll_below))
       expect_true(rel_diff < 0.01,
                   label = sprintf("K=3 boundary rel diff: %.6f (should be < 0.01)", rel_diff))
-    } else {
-      message("  K=3 full GAS at boundary hit numerical issues; fallback is stable")
     }
-  })
-})
-
-# =============================================================================
-# CATEGORY 12: Round-Trip Estimation Consistency
-# =============================================================================
-#
-# Generate data from a constant model, estimate with GAS model (which has
-# fallback enabled), verify parameter recovery. Uses minimal settings to
-# keep runtime short.
-
-describe("Round-trip estimation consistency", {
-  skip_on_cran()
-
-  it("recovers constant model parameters via GAS estimation (K=2 diagonal)", {
-    set.seed(1201)
-
-    mu1 <- -2; mu2 <- 2
-    sigma2_1 <- 0.5; sigma2_2 <- 0.6
-    p11 <- 0.85; p22 <- 0.90
-
-    const_par <- c(mu1, mu2, sigma2_1, sigma2_2, p11, p22)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 500, const_par, burn_in = 200)[1, ]
-
-    est_result <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = TRUE, A_threshold = 1e-4,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    # Estimated means should be close to true values (allow label switching)
-    mu_est <- sort(unname(est_result$mu_est))
-    mu_true <- sort(c(mu1, mu2))
-    expect_equal(mu_est, mu_true, tolerance = 0.5)
-
-    # Transition probabilities should be in a reasonable range
-    trans_est <- est_result$init_trans_est
-    expect_true(all(trans_est > 0.5 & trans_est < 1.0))
-  })
-
-  it("reports correct model_type_used in estimation metadata", {
-    set.seed(1202)
-
-    const_par <- c(-1.5, 1.5, 0.5, 0.6, 0.8, 0.9)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 500, const_par, burn_in = 200)[1, ]
-
-    est_result <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = TRUE, A_threshold = 1e-4,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    # model_type_used should be one of the valid values
-    expect_true(est_result$model_info$model_type_used %in%
-                  c("constant_fallback", "full_gas"))
-
-    # gas_settings should record the configuration
-    expect_true(est_result$gas_settings$use_fallback)
-    expect_equal(est_result$gas_settings$A_threshold, 1e-4)
-    expect_true(!is.null(est_result$gas_diagnostics))
-  })
-
-  it("GAS data with tiny A triggers fallback during estimation", {
-    set.seed(1203)
-
-    # Generate data with effectively zero A (constant dynamics)
-    gas_par <- c(-1.5, 1.5, 0.5, 0.6, 0.8, 0.9, 1e-6, 1e-6, 0.9, 0.9)
-    gas_par <- set_parameter_attributes(gas_par, K = 2, model_type = "gas",
-                                        diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataGASCD(1, 500, gas_par, burn_in = 200)[1, ]
-
-    est_result <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = TRUE, A_threshold = 1e-4,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    # With near-zero true A, estimated A should also be small
-    # or the model should have used the constant fallback
-    model_used <- est_result$model_info$model_type_used
-    A_est <- est_result$A_est
-
-    # Either fallback was used OR the estimated A is reasonably small
-    expect_true(model_used == "constant_fallback" || max(abs(A_est)) < 0.5,
-                label = sprintf("model_type_used=%s, max|A_est|=%.4f",
-                                model_used, max(abs(A_est))))
-  })
-})
-
-# =============================================================================
-# CATEGORY 13: Estimation Accuracy & Speed — Fallback vs No-Fallback
-# =============================================================================
-#
-# The full GAS path with near-zero A can hit numerical issues in score
-# calculation. These tests validate that fallback provides better numerical
-# stability and faster estimation. Uses minimal settings for speed.
-
-describe("Estimation accuracy and speed: fallback vs no-fallback", {
-  skip_on_cran()
-
-  it("fallback and non-fallback achieve comparable NLL for K=2", {
-    set.seed(1301)
-
-    const_par <- c(-1.5, 1.5, 0.5, 0.6, 0.85, 0.90)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 400, const_par, burn_in = 200)[1, ]
-
-    est_fallback <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = TRUE, A_threshold = 1e-4,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    est_no_fallback <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = FALSE,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    nll_fb <- est_fallback$diagnostics$neg_log_likelihood
-    nll_nofb <- est_no_fallback$diagnostics$neg_log_likelihood
-
-    # Both should find a valid minimum
-    expect_true(is.finite(nll_fb))
-    expect_true(is.finite(nll_nofb))
-
-    # With n_starts=1, the two paths may converge to different local optima.
-    # The key assertion is that fallback finds a result at least as good
-    # (lower NLL = higher likelihood), since the fallback avoids the
-    # computational overhead of near-zero GAS dynamics.
-    # Allow up to 25% relative difference (different optimization paths)
-    rel_diff <- abs(nll_fb - nll_nofb) / max(abs(nll_fb), abs(nll_nofb))
-    expect_true(rel_diff < 0.25,
-                label = sprintf("NLL rel diff: %.4f (should be < 0.25)", rel_diff))
-
-    message(sprintf("  Fallback NLL=%.4f, No-fallback NLL=%.4f, rel_diff=%.6f",
-                    nll_fb, nll_nofb, rel_diff))
-  })
-
-  it("fallback-enabled estimation is faster for constant-model data", {
-    set.seed(1302)
-
-    const_par <- c(-1.5, 1.5, 0.5, 0.6, 0.85, 0.90)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 400, const_par, burn_in = 200)[1, ]
-
-    time_fb <- system.time({
-      est_fb <- estimate_gas_model(
-        y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, n_burnin = 10, n_cutoff = 0,
-        use_fallback = TRUE, A_threshold = 1e-4,
-        parallel = FALSE, verbose = 0, seed = 42
-      )
-    })["elapsed"]
-
-    time_nofb <- system.time({
-      est_nofb <- estimate_gas_model(
-        y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, n_burnin = 10, n_cutoff = 0,
-        use_fallback = FALSE,
-        parallel = FALSE, verbose = 0, seed = 42
-      )
-    })["elapsed"]
-
-    # Fallback should be faster (or at worst comparable within noise)
-    expect_true(time_fb <= time_nofb * 1.5,
-                label = sprintf("Fallback (%.2fs) should be faster than no-fallback (%.2fs)",
-                                time_fb, time_nofb))
-
-    message(sprintf("  Estimation time: fallback=%.2fs, no-fallback=%.2fs",
-                    time_fb, time_nofb))
-  })
-
-  it("K=3 estimation: fallback succeeds where full GAS may fail", {
-    set.seed(1303)
-
-    const_par_k3 <- c(-2, 0, 2, 0.4, 0.5, 0.6, 0.8, 0.7, 0.85)
-    const_par_k3 <- set_parameter_attributes(const_par_k3, K = 3, model_type = "constant",
-                                             diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 400, const_par_k3, burn_in = 200)[1, ]
-
-    # Fallback should always succeed
-    est_fallback <- tryCatch(
-      estimate_gas_model(
-        y = y_data, K = 3, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, n_burnin = 10, n_cutoff = 0,
-        use_fallback = TRUE, A_threshold = 1e-4,
-        parallel = FALSE, verbose = 0, seed = 42
-      ),
-      error = function(e) NULL
-    )
-
-    # No-fallback may fail numerically for K=3
-    est_no_fallback <- tryCatch(
-      estimate_gas_model(
-        y = y_data, K = 3, diag_probs = TRUE, equal_variances = FALSE,
-        n_starts = 1, n_burnin = 10, n_cutoff = 0,
-        use_fallback = FALSE,
-        parallel = FALSE, verbose = 0, seed = 42
-      ),
-      error = function(e) NULL
-    )
-
-    # Fallback should always produce a valid result
-    expect_true(!is.null(est_fallback),
-                label = "K=3 fallback-enabled estimation should succeed")
-    if (!is.null(est_fallback)) {
-      expect_true(is.finite(est_fallback$diagnostics$neg_log_likelihood))
-    }
-
-    # Report outcome for informational purposes
-    if (is.null(est_no_fallback)) {
-      message("  K=3 no-fallback estimation failed numerically (expected)")
-    } else {
-      message(sprintf("  K=3: fallback NLL=%.4f, no-fallback NLL=%.4f",
-                      est_fallback$diagnostics$neg_log_likelihood,
-                      est_no_fallback$diagnostics$neg_log_likelihood))
-    }
-  })
-
-  it("fallback and non-fallback find comparable log-likelihood values (K=2)", {
-    set.seed(1304)
-
-    const_par <- c(-2, 2, 0.4, 0.6, 0.80, 0.85)
-    const_par <- set_parameter_attributes(const_par, K = 2, model_type = "constant",
-                                          diag_probs = TRUE, equal_variances = FALSE)
-    y_data <- dataConstCD(1, 400, const_par, burn_in = 200)[1, ]
-
-    est_fb <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = TRUE, A_threshold = 1e-4,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    est_nofb <- estimate_gas_model(
-      y = y_data, K = 2, diag_probs = TRUE, equal_variances = FALSE,
-      n_starts = 1, n_burnin = 10, n_cutoff = 0,
-      use_fallback = FALSE,
-      parallel = FALSE, verbose = 0, seed = 42
-    )
-
-    ll_fb <- est_fb$diagnostics$log_likelihood
-    ll_nofb <- est_nofb$diagnostics$log_likelihood
-
-    # Both should find reasonable log-likelihoods
-    expect_true(is.finite(ll_fb))
-    expect_true(is.finite(ll_nofb))
-
-    # With n_starts=1, the two paths may converge to different local optima
-    # due to different likelihood evaluation during optimization. Allow up to
-    # 25% relative difference. The key test is that both find valid optima.
-    rel_diff <- abs(ll_fb - ll_nofb) / max(abs(ll_fb), abs(ll_nofb))
-    expect_true(rel_diff < 0.25,
-                label = sprintf("Log-likelihood rel diff: %.4f (should be < 0.25)", rel_diff))
   })
 })
 
@@ -1827,16 +1032,9 @@ describe("Verbose output coverage", {
 # ===========================================================================
 
 test_that("estimate_gas_model default bounds include log-variance floor", {
-  # Simulate a minimal call to inspect the bounds
-  # The bounds are set inside estimate_gas_model when bounds=NULL
-  # We verify indirectly by checking the function doesn't produce
-  # "Total likelihood is too small" warnings during optimization
   K <- 2
   n_sigma2 <- K
   expected_floor <- log(1e-10)
-
-  # The lower bounds for sigma2 should be log(1e-10) not -Inf
-  # This is a structural test: verify the constant is what we expect
 
   expect_equal(expected_floor, log(1e-10))
   expect_true(expected_floor > -Inf)
@@ -1852,9 +1050,8 @@ test_that("estimate_gas_model does not flood warnings during optimization", {
   warnings_captured <- character(0)
   withCallingHandlers(
     result <- estimate_gas_model(y, K = 2, diag_probs = TRUE,
-                                  n_starts = 3, verbose = 0,
-                                  n_burnin = 20, n_cutoff = 10,
-                                  parallel = FALSE),
+                                  n_starts = 4, verbose = 0,
+                                  n_burnin = 20, n_cutoff = 10),
     warning = function(w) {
       warnings_captured <<- c(warnings_captured, conditionMessage(w))
       invokeRestart("muffleWarning")
@@ -1871,10 +1068,6 @@ test_that("Rfiltering_GAS still warns when called directly with bad params", {
   set.seed(42)
   y <- c(rnorm(100, -2, sqrt(0.5)), rnorm(100, 2, sqrt(1.5)))
 
-  # Create parameters where mu values are moderately misplaced and sigma2 is
-  # small enough that some (but not all) time points produce tiny tot_lik.
-  # mu1=-2, mu2=2 match the data, but sigma2=0.001 makes the density very
-  # narrow — observations far from either mean will underflow.
   par <- c(-2, 2, 0.001, 0.001, 0.9, 0.9, 0.01, 0.01, 0.8, 0.8)
   par <- set_parameter_attributes(par, K = 2, model_type = "gas",
                                   diag_probs = TRUE, equal_variances = FALSE)

--- a/tests/testthat/test-model-estimation.R
+++ b/tests/testthat/test-model-estimation.R
@@ -8,7 +8,7 @@ test_that("constant model estimation works with off-diagonal parameterization", 
   y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
 
   result <- estimate_constant_model(y, K = 2, diag_probs = FALSE,
-                                    n_starts = 5, verbose = 0)
+                                    n_starts = 4, verbose = 0)
   expect_equal(result$diagnostics$convergence_code, 0)
   expect_true(is.finite(result$diagnostics$neg_log_likelihood))
   # Regime means should be roughly -1 and 1 (order may differ)
@@ -22,7 +22,7 @@ test_that("constant model estimation still works with diagonal parameterization"
   y <- c(rnorm(200, -1, 0.5), rnorm(200, 1, 0.7))
 
   result <- estimate_constant_model(y, K = 2, diag_probs = TRUE,
-                                    n_starts = 5, verbose = 0)
+                                    n_starts = 4, verbose = 0)
   expect_equal(result$diagnostics$convergence_code, 0)
   expect_true(is.finite(result$diagnostics$neg_log_likelihood))
 })
@@ -149,7 +149,7 @@ test_that("constant model estimation works with K=3 off-diagonal", {
   y <- c(rnorm(150, -2, 0.5), rnorm(150, 0, 0.5), rnorm(150, 2, 0.5))
 
   result <- estimate_constant_model(y, K = 3, diag_probs = FALSE,
-                                    n_starts = 5, verbose = 0)
+                                    n_starts = 4, verbose = 0)
   expect_equal(result$diagnostics$convergence_code, 0)
   expect_true(is.finite(result$diagnostics$neg_log_likelihood))
 })


### PR DESCRIPTION
## Summary
- **test-gas-fallback.R**: Remove redundant categories (performance benchmarks, duplicate estimation tests) and consolidate overlapping tests — 71→44 blocks, 1887→1081 lines
- **test-convergence-diagnostics.R**: Enable parallel, reduce N and n_starts to 4, fix pre-existing `B`/`C`→`n_burnin`/`n_cutoff` rename missed from #37
- **test-early-stopping.R**: Enable parallel, align n_starts=4
- **test-model-estimation.R**: Reduce n_starts from 5 to 4

## Test plan
- [x] Full `devtools::test()` passes: FAIL 0 | WARN 146 | SKIP 1 | PASS 529
- [x] Verify local suite completes faster than before

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)