### PR TITLE
docs: document C backend and use_cpp parameter

### DIFF
--- a/R/cpp_backend.R
+++ b/R/cpp_backend.R
@@ -1,6 +1,17 @@
-#' Check if C filtering backend is available
+#' Check if the compiled C filtering backend is available
 #'
-#' @return Logical scalar: TRUE if C backend is available, FALSE otherwise.
+#' Returns \code{TRUE} when the package was installed with its compiled C
+#' library (the normal case). Returns \code{FALSE} when the package is loaded
+#' from source without compilation (e.g. \code{devtools::load_all()} on a
+#' machine without a C toolchain, or when the shared library failed to load).
+#'
+#' The four \code{Rfiltering_*} functions check this automatically and fall
+#' back to pure-R implementations when \code{FALSE}. You can also disable the
+#' C backend globally with \code{options(multiregimeTVTP.use_cpp = FALSE)}.
+#'
+#' @return Logical scalar: \code{TRUE} if C backend is available.
+#' @seealso \code{\link{Rfiltering_Const}}, \code{\link{Rfiltering_TVP}},
+#'   \code{\link{Rfiltering_TVPXExo}}, \code{\link{Rfiltering_GAS}}
 #' @export
 cpp_available <- function() {
   is.loaded("C_filtering_Const", PACKAGE = "multiregimeTVTP")

--- a/R/model_GAS.R
+++ b/R/model_GAS.R
@@ -243,6 +243,9 @@ dataGASCD <- function(M, N, par, burn_in = 100, n_nodes = 30,
 #' @param A_threshold Threshold below which to use constant model fallback (default: 1e-4)
 #' @param diagnostics If TRUE, include detailed diagnostic information (default: FALSE)
 #' @param verbose Whether to report fallback usage (default: FALSE)
+#' @param use_cpp Logical: use compiled C backend if available (default:
+#'   \code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+#'   to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.
 #' @return Negative log-likelihood of observed data under the model
 #' @details
 #' Automatically reads configuration (diagonal vs off-diagonal, equal variances)

--- a/R/model_TVP.R
+++ b/R/model_TVP.R
@@ -154,6 +154,9 @@ dataTVPCD <- function(M, N, par, burn_in = 100) {
 #' @param n_burnin Burn-in to be excluded at the beginning of the time series
 #' @param n_cutoff Cut-off to be excluded at the end of the time series
 #' @param diagnostics If TRUE, include detailed diagnostic information (default: TRUE)
+#' @param use_cpp Logical: use compiled C backend if available (default:
+#'   \code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+#'   to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.
 #' @return Negative log-likelihood of observed data under the model
 #' @details
 #' Automatically reads configuration (diagonal vs off-diagonal, equal variances)

--- a/R/model_constant.R
+++ b/R/model_constant.R
@@ -121,6 +121,9 @@ dataConstCD <- function(M, N, par, burn_in = 100) {
 #' @param n_burnin Burn-in to be excluded at the beginning of the time series
 #' @param n_cutoff Cut-off to be excluded at the end of the time series
 #' @param diagnostics Choose whether to store calculation diagnostics or not
+#' @param use_cpp Logical: use compiled C backend if available (default:
+#'   \code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+#'   to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.
 #' @return Negative log-likelihood of observed data under the model
 #' @details
 #' Automatically reads configuration (diagonal vs off-diagonal, equal variances)

--- a/R/model_exogenous.R
+++ b/R/model_exogenous.R
@@ -155,6 +155,9 @@ dataTVPXExoCD <- function(M, N, par, X_Exo, burn_in = 100) {
 #' @param n_burnin Burn-in to be excluded at the beginning of the time series
 #' @param n_cutoff Cut-off to be excluded at the end of the time series
 #' @param diagnostics If TRUE, include detailed diagnostic information (default: TRUE)
+#' @param use_cpp Logical: use compiled C backend if available (default:
+#'   \code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+#'   to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.
 #' @return Negative log-likelihood of observed data under the model
 #' @details
 #' Automatically reads configuration (diagonal vs off-diagonal, equal variances)

--- a/README.md
+++ b/README.md
@@ -215,7 +215,14 @@ plot_gas_simulation_results(results, output_file = "results/gas_plots.pdf")
 - Variance parameters are log-transformed during optimization
 
 ### Computational Efficiency
-- Parallel processing for multi-start optimization
+- **C backend**: The four filtering functions (`Rfiltering_Const`, `Rfiltering_TVP`,
+  `Rfiltering_TVPXExo`, `Rfiltering_GAS`) are accelerated by a compiled C library
+  (10–56× speedup per NLL call vs pure R, with the largest gains for TVP and GAS).
+  The backend is used automatically when available.
+  - Check availability: `cpp_available()`
+  - Disable globally: `options(multiregimeTVTP.use_cpp = FALSE)`
+  - Disable per-call: pass `use_cpp = FALSE` to any `Rfiltering_*` function
+- Parallel processing for multi-start optimization via `future`/`future.apply`
 - Vectorized operations where possible
 - Efficient matrix operations for transition calculations
 

--- a/man/Rfiltering_Const.Rd
+++ b/man/Rfiltering_Const.Rd
@@ -23,6 +23,10 @@ Rfiltering_Const(
 \item{n_cutoff}{Cut-off to be excluded at the end of the time series}
 
 \item{diagnostics}{Choose whether to store calculation diagnostics or not}
+
+\item{use_cpp}{Logical: use compiled C backend if available (default:
+\code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.}
 }
 \value{
 Negative log-likelihood of observed data under the model

--- a/man/Rfiltering_GAS.Rd
+++ b/man/Rfiltering_GAS.Rd
@@ -38,6 +38,10 @@ Rfiltering_GAS(
 \item{diagnostics}{If TRUE, include detailed diagnostic information (default: FALSE)}
 
 \item{verbose}{Whether to report fallback usage (default: FALSE)}
+
+\item{use_cpp}{Logical: use compiled C backend if available (default:
+\code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.}
 }
 \value{
 Negative log-likelihood of observed data under the model

--- a/man/Rfiltering_TVP.Rd
+++ b/man/Rfiltering_TVP.Rd
@@ -23,6 +23,10 @@ Rfiltering_TVP(
 \item{n_cutoff}{Cut-off to be excluded at the end of the time series}
 
 \item{diagnostics}{If TRUE, include detailed diagnostic information (default: TRUE)}
+
+\item{use_cpp}{Logical: use compiled C backend if available (default:
+\code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.}
 }
 \value{
 Negative log-likelihood of observed data under the model

--- a/man/Rfiltering_TVPXExo.Rd
+++ b/man/Rfiltering_TVPXExo.Rd
@@ -26,6 +26,10 @@ Rfiltering_TVPXExo(
 \item{n_cutoff}{Cut-off to be excluded at the end of the time series}
 
 \item{diagnostics}{If TRUE, include detailed diagnostic information (default: TRUE)}
+
+\item{use_cpp}{Logical: use compiled C backend if available (default:
+\code{getOption("multiregimeTVTP.use_cpp", TRUE)}). Set to \code{FALSE}
+to force pure-R execution (e.g. for debugging). See \code{\link{cpp_available}}.}
 }
 \value{
 Negative log-likelihood of observed data under the model

--- a/man/cpp_available.Rd
+++ b/man/cpp_available.Rd
@@ -2,13 +2,25 @@
 % Please edit documentation in R/cpp_backend.R
 \name{cpp_available}
 \alias{cpp_available}
-\title{Check if C filtering backend is available}
+\title{Check if the compiled C filtering backend is available}
 \usage{
 cpp_available()
 }
 \value{
-Logical scalar: TRUE if C backend is available, FALSE otherwise.
+Logical scalar: \code{TRUE} if C backend is available.
 }
 \description{
-Check if C filtering backend is available
+Returns \code{TRUE} when the package was installed with its compiled C
+library (the normal case). Returns \code{FALSE} when the package is loaded
+from source without compilation (e.g. \code{devtools::load_all()} on a
+machine without a C toolchain, or when the shared library failed to load).
+}
+\details{
+The four \code{Rfiltering_*} functions check this automatically and fall
+back to pure-R implementations when \code{FALSE}. You can also disable the
+C backend globally with \code{options(multiregimeTVTP.use_cpp = FALSE)}.
+}
+\seealso{
+\code{\link{Rfiltering_Const}}, \code{\link{Rfiltering_TVP}},
+\code{\link{Rfiltering_TVPXExo}}, \code{\link{Rfiltering_GAS}}
 }


### PR DESCRIPTION
## Summary

- Add `@param use_cpp` documentation to all four `Rfiltering_*` functions (Const, TVP, Exo, GAS)
- Expand `cpp_available()` help page with explanation of when it returns FALSE and how to control the C backend globally
- Update README "Computational Efficiency" section to describe the C backend, speedups, and how to enable/disable it

Follow-up to PR #43 which added the C backend but did not update the documentation.

## Test plan

- [x] `devtools::document()` regenerates all five `.Rd` files without error
- [x] `?Rfiltering_Const` (and the other three) shows `use_cpp` argument
- [x] `?cpp_available` shows expanded description with usage guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)