### PR TITLE
docs: credit Yushu Li in acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,4 +294,10 @@ For questions, issues, or contributions, please open an issue on GitHub.
 
 ## Acknowledgments
 
-This implementation incorporates ideas from Bazzi et al. (2017) for score-driven dynamics.
+- **Yushu Li** (co-supervisor, <yushu.li@uib.no>) — wrote the initial
+  2-regime R implementation of the data-simulation, filtering, and
+  estimation functions for the TVP, exogenous-driven, and GAS models,
+  translating the filtering/estimation routines from C in the HMMGAS
+  package. This package extends her 2-regime code to arbitrary K.
+- Bazzi et al. (2017) — score-driven (GAS) methodology and the reference
+  HMMGAS implementation.


### PR DESCRIPTION
## Summary

- Expands the `Acknowledgments` section of the README to credit co-supervisor **Yushu Li** (<yushu.li@uib.no>) for the initial 2-regime R implementation of the data-simulation, filtering, and estimation functions that this package's K-regime generalization is built on, including her C-to-R translation of filtering/estimation routines from the HMMGAS package.
- Attributes the score-driven (GAS) methodology and the HMMGAS reference implementation to Bazzi et al. (2017).

## Test plan

- [ ] Render README on GitHub and confirm the Acknowledgments section displays the two bullets with the email rendered as a clickable `mailto:` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)