### PR TITLE
docs: reword Yushu Li acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,8 @@ For questions, issues, or contributions, please open an issue on GitHub.
 ## Acknowledgments
 
 - **Yushu Li** (co-supervisor, <yushu.li@uib.no>) — wrote the initial
-  2-regime R implementation of the data-simulation, filtering, and
-  estimation functions for the TVP, exogenous-driven, and GAS models,
-  translating the filtering/estimation routines from C in the HMMGAS
-  package. This package extends her 2-regime code to arbitrary K.
+  2-regime R code of the data-simulation, filtering/estimation routines
+  based on C code in the HMMGAS package. This package extends the
+  2-regime code to arbitrary K.
 - Bazzi et al. (2017) — score-driven (GAS) methodology and the reference
   HMMGAS implementation.


### PR DESCRIPTION
## Summary

- Tightens the phrasing of the Yushu Li acknowledgement in the README — "R code of the data-simulation, filtering/estimation routines based on C code in the HMMGAS package" in place of the longer per-model description from #46.

## Test plan

- [ ] Render the Acknowledgments section on GitHub and confirm the bullet reads cleanly and the `mailto:` link still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)